### PR TITLE
Concourse: scaleable key mgmt + features

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -43,10 +43,9 @@ postgres_password="$(
   | jq -r .Parameter.Value
 )"
 
-aws ssm get-parameter \
-  --name /${deployment}/concourse/web/authorised_worker_keys \
-  --with-decryption \
-| jq -r .Parameter.Value > /opt/concourse/keys/workers
+aws s3 cp \
+          s3://${concourse_web_bucket}/${worker_keys_s3_object_key} \
+          /opt/concourse/keys/workers
 
 aws ssm get-parameter \
   --name /${deployment}/concourse/web/ssh_key \

--- a/reliability-engineering/terraform/modules/concourse-web/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/iam.tf
@@ -63,6 +63,34 @@ resource "aws_iam_policy" "concourse_web" {
           "${aws_kms_key.concourse_web.arn}",
           "${aws_kms_key.concourse_worker_shared.arn}"
         ]
+      }, {
+        "Effect": "Allow",
+        "Action": [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject",
+          "s3:DeleteObjectTagging",
+          "s3:DeleteObjectVersion",
+          "s3:DeleteObjectVersionTagging",
+          "s3:GetObject",
+          "s3:GetObjectAcl",
+          "s3:GetObjectTagging",
+          "s3:GetObjectTorrent",
+          "s3:GetObjectVersion",
+          "s3:GetObjectVersionAcl",
+          "s3:GetObjectVersionTagging",
+          "s3:GetObjectVersionTorrent",
+          "s3:ListMultipartUploadParts",
+          "s3:PutObject",
+          "s3:PutObjectAcl",
+          "s3:PutObjectTagging",
+          "s3:PutObjectVersionAcl",
+          "s3:PutObjectVersionTagging",
+          "s3:RestoreObject"
+        ],
+        "Resource": [
+          "${aws_s3_bucket.concourse_web.arn}",
+          "${aws_s3_bucket.concourse_web.arn}/*"
+        ]
       }
     ]
   }

--- a/reliability-engineering/terraform/modules/concourse-web/keys.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/keys.tf
@@ -96,10 +96,6 @@ resource "aws_ssm_parameter" "concourse_worker_ssh_private_keys" {
     count.index
   )}"
 
-  lifecycle {
-    ignore_changes = ["value"]
-  }
-
   tags = {
     Deployment = "${var.deployment}"
   }
@@ -146,18 +142,6 @@ resource "aws_ssm_parameter" "concourse_web_session_key" {
   }
 }
 
-resource "aws_ssm_parameter" "concourse_web_authorized_worker_keys" {
-  name        = "/${var.deployment}/concourse/web/authorised_worker_keys"
-  type        = "SecureString"
-  description = "Authorised worker public keys in OpenSSH format"
-  value       = "${local.concourse_worker_openssh_public_keys}"
-  key_id      = "${aws_kms_key.concourse_web.id}"
-
-  tags = {
-    Deployment = "${var.deployment}"
-  }
-}
-
 resource "aws_ssm_parameter" "concourse_web_db_password" {
   name        = "/${var.deployment}/concourse/web/db_password"
   type        = "SecureString"
@@ -168,4 +152,11 @@ resource "aws_ssm_parameter" "concourse_web_db_password" {
   tags = {
     Deployment = "${var.deployment}"
   }
+}
+
+resource "aws_s3_bucket_object" "concourse_web_authorized_worker_keys" {
+  bucket  = "${aws_s3_bucket.concourse_web.bucket}"
+  key     = "authorized_worker_keys"
+  content = "${local.concourse_worker_openssh_public_keys}"
+  etag    = "${md5(local.concourse_worker_openssh_public_keys)}"
 }

--- a/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
@@ -20,6 +20,9 @@ data "template_file" "concourse_web_cloud_init" {
     concourse_db_url         = "${aws_route53_record.concourse_private_db.fqdn}"
     concourse_version        = "v4.2.2"
     concourse_sha1           = "c40f1b97bd45b9d52962616562bf6ff77731b542  concourse_linux_amd64"
+
+    concourse_web_bucket      = "${aws_s3_bucket.concourse_web.bucket}"
+    worker_keys_s3_object_key = "${aws_s3_bucket_object.concourse_web_authorized_worker_keys.id}"
   }
 }
 

--- a/reliability-engineering/terraform/modules/concourse-web/s3.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/s3.tf
@@ -1,0 +1,23 @@
+resource "random_string" "concourse_web_s3_bucket_offset" {
+  length  = 6
+  special = false
+  upper   = false
+  number  = false
+}
+
+resource "aws_s3_bucket" "concourse_web" {
+  bucket = "${var.deployment}-concourse-web-${random_string.concourse_web_s3_bucket_offset.result}"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/ecr.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/ecr.tf
@@ -1,0 +1,77 @@
+resource "random_string" "concourse_worker_private_ecr_repo" {
+  length  = 6
+  special = false
+  upper   = false
+  number  = false
+}
+
+resource "aws_ecr_repository" "concourse_worker_private" {
+  name = "${ join("-", list(
+    var.deployment, var.name, "private",
+    random_string.concourse_worker_private_ecr_repo.result
+  ))}"
+
+  tags {
+    Deployment = "${var.deployment}"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "concourse_worker_private_last_900" {
+  repository = "${aws_ecr_repository.concourse_worker_private.name}"
+
+  policy = <<-POLICY
+  {
+    "rules": [
+      {
+        "rulePriority": 1,
+        "description": "Keep only last 900 images",
+        "selection": {
+          "tagStatus": "untagged",
+          "countType": "imageCountMoreThan",
+          "countNumber": 900
+        },
+        "action": {
+          "type": "expire"
+        }
+      }
+    ]
+  }
+  POLICY
+}
+
+resource "aws_ecr_repository_policy" "concourse_worker_private" {
+  repository = "${aws_ecr_repository.concourse_worker_private.name}"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Deny",
+      "Action": [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload"
+      ],
+      "Principal": {"AWS": ["*"]}
+    }, {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload"
+      ],
+      "Principal": {
+        "AWS": ["${aws_iam_role.concourse_worker.arn}"]
+      }
+    }]
+  }
+  EOF
+}

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
@@ -55,11 +55,21 @@ resource "aws_iam_policy" "concourse_worker_base" {
           "ssm:GetParameter",
           "ssm:GetParameters",
           "ssm:GetParametersByPath",
-          "ssm:DeleteParameter"
+          "ssm:DeleteParameter",
+          "ssm:PutParameter"
         ],
         "Effect": "Allow",
         "Resource": [
           "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/concourse/pipelines/${var.name}/*"
+        ]
+      }, {
+        "Action": [
+          "ssm:DeleteParameter",
+          "ssm:PutParameter"
+        ],
+        "Effect": "Deny",
+        "Resource": [
+          "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/concourse/pipelines/${var.name}/readonly_*"
         ]
       }, {
         "Effect": "Allow",
@@ -73,6 +83,60 @@ resource "aws_iam_policy" "concourse_worker_base" {
       }, {
         "Effect": "Allow",
         "Action": ["sts:AssumeRole"],
+        "Resource": "*"
+      }, {
+        "Effect": "Allow",
+        "Action": [
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject",
+          "s3:DeleteObjectTagging",
+          "s3:DeleteObjectVersion",
+          "s3:DeleteObjectVersionTagging",
+          "s3:GetObject",
+          "s3:GetObjectAcl",
+          "s3:GetObjectTagging",
+          "s3:GetObjectTorrent",
+          "s3:GetObjectVersion",
+          "s3:GetObjectVersionAcl",
+          "s3:GetObjectVersionTagging",
+          "s3:GetObjectVersionTorrent",
+          "s3:ListMultipartUploadParts",
+          "s3:PutObject",
+          "s3:PutObjectAcl",
+          "s3:PutObjectTagging",
+          "s3:PutObjectVersionAcl",
+          "s3:PutObjectVersionTagging",
+          "s3:RestoreObject",
+          "s3:ListBucket",
+          "s3:ListBucketVersions"
+        ],
+        "Resource": [
+          "${aws_s3_bucket.concourse_worker_private.arn}",
+          "${aws_s3_bucket.concourse_worker_private.arn}/*",
+          "${aws_s3_bucket.concourse_worker_public.arn}",
+          "${aws_s3_bucket.concourse_worker_public.arn}/*"
+        ]
+      }, {
+        "Effect": "Deny",
+        "Action": [
+          "s3:DeleteObject",
+          "s3:DeleteObjectTagging",
+          "s3:DeleteObjectVersion",
+          "s3:DeleteObjectVersionTagging",
+          "s3:PutObject",
+          "s3:PutObjectAcl",
+          "s3:PutObjectTagging",
+          "s3:PutObjectVersionAcl",
+          "s3:PutObjectVersionTagging",
+          "s3:RestoreObject"
+        ],
+        "Resource": [
+          "${aws_s3_bucket.concourse_worker_private.arn}/readonly/*",
+          "${aws_s3_bucket.concourse_worker_public.arn}/readonly/*"
+        ]
+      }, {
+        "Effect": "Allow",
+        "Action": ["ecr:GetAuthorizationToken"],
         "Resource": "*"
       }
     ]

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/pipeline-helpers.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/pipeline-helpers.tf
@@ -1,0 +1,119 @@
+resource "aws_ssm_parameter" "concourse_worker_private_bucket_name" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_private_bucket_name"
+
+  type        = "String"
+  description = "Private s3 bucket name for ${var.deployment}/${var.name}"
+  value       = "${aws_s3_bucket.concourse_worker_private.bucket}"
+
+  tags = {
+    Deployment = "${var.deployment}"
+  }
+}
+
+resource "aws_ssm_parameter" "concourse_worker_private_bucket_arn" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_private_bucket_arn"
+
+  type        = "String"
+  description = "Private s3 bucket arn for ${var.deployment}/${var.name}"
+  value       = "${aws_s3_bucket.concourse_worker_private.arn}"
+
+  tags = {
+    Deployment = "${var.deployment}"
+  }
+}
+
+resource "aws_ssm_parameter" "concourse_worker_private_bucket_domain_name" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_private_bucket_domain_name"
+
+  type        = "String"
+  description = "Private s3 bucket domain name for ${var.deployment}/${var.name}"
+  value       = "${aws_s3_bucket.concourse_worker_private.bucket_domain_name}"
+
+  tags = {
+    Deployment = "${var.deployment}"
+  }
+}
+
+resource "aws_ssm_parameter" "concourse_worker_public_bucket_name" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_public_bucket_name"
+
+  type        = "String"
+  description = "Public s3 bucket name for ${var.deployment}/${var.name}"
+  value       = "${aws_s3_bucket.concourse_worker_public.bucket}"
+
+  tags = {
+    Deployment = "${var.deployment}"
+  }
+}
+
+resource "aws_ssm_parameter" "concourse_worker_public_bucket_arn" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_public_bucket_arn"
+
+  type        = "String"
+  description = "Public s3 bucket arn for ${var.deployment}/${var.name}"
+  value       = "${aws_s3_bucket.concourse_worker_public.arn}"
+
+  tags = {
+    Deployment = "${var.deployment}"
+  }
+}
+
+resource "aws_ssm_parameter" "concourse_worker_public_bucket_domain_name" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_public_bucket_domain_name"
+
+  type        = "String"
+  description = "Public s3 bucket domain name for ${var.deployment}/${var.name}"
+  value       = "${aws_s3_bucket.concourse_worker_public.bucket_domain_name}"
+
+  tags = {
+    Deployment = "${var.deployment}"
+  }
+}
+
+resource "aws_ssm_parameter" "concourse_worker_private_ecr_repo_name" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_private_ecr_repo_name"
+
+  type        = "String"
+  description = "Private ecr repo name for ${var.deployment}/${var.name}"
+  value       = "${aws_ecr_repository.concourse_worker_private.name}"
+
+  tags = {
+    Deployment = "${var.deployment}"
+  }
+}
+
+resource "aws_ssm_parameter" "concourse_worker_private_ecr_repo_arn" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_private_ecr_repo_arn"
+
+  type        = "String"
+  description = "Private ecr repo arn for ${var.deployment}/${var.name}"
+  value       = "${aws_ecr_repository.concourse_worker_private.arn}"
+
+  tags = {
+    Deployment = "${var.deployment}"
+  }
+}
+
+resource "aws_ssm_parameter" "concourse_worker_private_ecr_repo_url" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_private_ecr_repo_url"
+
+  type        = "String"
+  description = "Private ecr repo name for ${var.deployment}/${var.name}"
+  value       = "${aws_ecr_repository.concourse_worker_private.repository_url}"
+
+  tags = {
+    Deployment = "${var.deployment}"
+  }
+}
+
+resource "aws_ssm_parameter" "concourse_worker_private_ecr_repo_registry_id" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_private_ecr_repo_registry_id"
+
+  type        = "String"
+  description = "Private ecr repo registry id for ${var.deployment}/${var.name}"
+  value       = "${aws_ecr_repository.concourse_worker_private.registry_id}"
+
+  tags = {
+    Deployment = "${var.deployment}"
+  }
+}

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/s3.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/s3.tf
@@ -1,0 +1,47 @@
+resource "random_string" "concourse_worker_private_s3_bucket_offset" {
+  length  = 6
+  special = false
+  upper   = false
+  number  = false
+}
+
+resource "aws_s3_bucket" "concourse_worker_private" {
+  bucket = "${var.deployment}-${var.name}-private-${random_string.concourse_worker_private_s3_bucket_offset.result}"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "random_string" "concourse_worker_public_s3_bucket_offset" {
+  length  = 6
+  special = false
+  upper   = false
+  number  = false
+}
+
+resource "aws_s3_bucket" "concourse_worker_public" {
+  bucket = "${var.deployment}-${var.name}-public-${random_string.concourse_worker_public_s3_bucket_offset.result}"
+  acl    = "public-read"
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}


### PR DESCRIPTION
1) Use S3 instead of parameter store for concourse worker public keys, this is due to the size limit of 4096 in parameter store which is insufficient for more than 5 or 6 4k ssh public keys

2) Add features to tenants

- Public s3 bucket
- Private s3 bucket
- Private ecr repo (hacky read commit message)
- readonly variables which describe the buckets and repo