### PR TITLE
Use worker role arns directly in concourse-keys

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-keys/shared.tf
+++ b/reliability-engineering/terraform/modules/concourse-keys/shared.tf
@@ -1,19 +1,10 @@
 locals {
-  kms_principal_template = "arn:aws:iam::${data.aws_caller_identity.account.account_id}"
-
-  kms_root_principal = "${local.kms_principal_template}:root"
-
-  kms_worker_principals = "${formatlist(
-    "${local.kms_principal_template}:role/${var.deployment}-%s-concourse-worker",
-    var.worker_team_names
-  )}"
-
   kms_principals = "${concat(
     list(
-      local.kms_root_principal,
+      "arn:aws:iam::${data.aws_caller_identity.account.account_id}:root",
       aws_iam_role.concourse_web.arn,
     ),
-    local.kms_worker_principals
+    aws_iam_role.concourse_workers.*.arn
   )}"
 }
 


### PR DESCRIPTION
Before the worker roles were created in separate modules, we've
refactored this behaviour to be done in the concourse-keys module.

If we use the role arns directly it introduces an explicit dependency in
the terraform graph which forces the roles to be created before the kms
key policy is updated, this fixes the race condition when provisioning a
new team.

When applying this change it is a no-op