### PR TITLE
Fix ECR permissions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "reliability-engineering/bosh/modules/jumpbox-deployment"]
+	path = reliability-engineering/bosh/modules/jumpbox-deployment
+	url = git@github.com:cloudfoundry/jumpbox-deployment.git

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/ecr.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/ecr.tf
@@ -50,18 +50,6 @@ resource "aws_ecr_repository_policy" "concourse_worker_private" {
   {
     "Version": "2012-10-17",
     "Statement": [{
-      "Effect": "Deny",
-      "Action": [
-        "ecr:GetDownloadUrlForLayer",
-        "ecr:BatchGetImage",
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:PutImage",
-        "ecr:InitiateLayerUpload",
-        "ecr:UploadLayerPart",
-        "ecr:CompleteLayerUpload"
-      ],
-      "Principal": {"AWS": ["*"]}
-    }, {
       "Effect": "Allow",
       "Action": [
         "ecr:GetDownloadUrlForLayer",

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
@@ -117,6 +117,24 @@ resource "aws_iam_policy" "concourse_worker_base" {
         ]
       }, {
         "Effect": "Allow",
+        "Action": [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:CompleteLayerUpload",
+          "ecr:DescribeImages",
+          "ecr:DescribeRepositories",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:InitiateLayerUpload",
+          "ecr:ListImages",
+          "ecr:PutImage",
+          "ecr:UploadLayerPart"
+        ],
+        "Resource": [
+          "${aws_ecr_repository.concourse_worker_private.arn}",
+          "${aws_ecr_repository.concourse_worker_private.arn}/*"
+        ]
+      }, {
+        "Effect": "Allow",
         "Action": ["ecr:GetAuthorizationToken"],
         "Resource": "*"
       }


### PR DESCRIPTION
The explicit deny is not needed and overrides the explicit allow

Add additional permissions to the individual worker to let it do things to its own repo

Signed-off-by: Toby Lorne <toby.lornewelch-richards@digital.cabinet-office.gov.uk>