### PR TITLE
Use anchors to tidy the pipeline and re-use code.

### DIFF
--- a/reliability-engineering/pipelines/internal-apps.yml
+++ b/reliability-engineering/pipelines/internal-apps.yml
@@ -26,21 +26,24 @@ jobs:
             source:
               repository: gdsre/aws-ruby
               tag: 2.6.1-3.0.1
+          params: 
+            GIT_DIR: re-team-manual-git
+            BUNDLE_DIR: re-team-manual-bundled   
           inputs:
             - name: re-team-manual-git
           outputs:
             - name: re-team-manual-bundled
-          run:
+          run: &bundle
             path: sh
             args:
             - -c
             - |
-              cd re-team-manual-git
+              cd $GIT_DIR
               apt-get update
               apt-get install -y nodejs
               bundle install --without development
               bundle exec middleman build
-              cp -r . ../re-team-manual-bundled
+              cp -r . ../$BUNDLE_DIR
       - task: deploy-re-team-manual-to-paas
         timeout: 5m
         config: 
@@ -56,18 +59,20 @@ jobs:
             CF_USER: ((cf_user))
             CF_PASS: ((cf_password))
             CF_SPACE: docs
+            BUNDLE_DIR: re-team-manual-bundled
+            APP_NAME: re-team-manual
           inputs:
             - name: re-team-manual-bundled
-          run:
+          run: &deploy
             path: bash
             dir: re-team-manual
             args:
               - -c
               - |
                 set -eu
-                cd ../re-team-manual-bundled
+                cd ../$BUNDLE_DIR
                 cf login -a $CF_API -u $CF_USER -p $CF_PASS -o $CF_ORG -s $CF_SPACE
-                cf push -f manifest.yml re-team-manual
+                cf push -f manifest.yml $APP_NAME
 
   - name: deploy-reliability-engineering
     serial: true
@@ -83,21 +88,14 @@ jobs:
             source:
               repository: gdsre/aws-ruby
               tag: 2.6.1-3.0.1
+          params:
+            GIT_DIR: reliability-engineering-git
+            BUNDLE_DIR: reliability-engineering-bundled              
           inputs:
             - name: reliability-engineering-git
           outputs:
             - name: reliability-engineering-bundled
-          run:
-            path: sh
-            args:
-            - -c
-            - |
-              cd reliability-engineering-git
-              apt-get update
-              apt-get install -y nodejs
-              bundle install --without development
-              bundle exec middleman build
-              cp -r . ../reliability-engineering-bundled
+          run: *bundle
       - task: deploy-reliability-engineering-to-paas
         timeout: 5m
         config: 
@@ -113,16 +111,8 @@ jobs:
             CF_USER: ((cf_user))
             CF_PASS: ((cf_password))
             CF_SPACE: docs
+            BUNDLE_DIR: reliability-engineering-bundled
+            APP_NAME: reliability-engineering
           inputs:
             - name: reliability-engineering-bundled
-          run:
-            path: bash
-            dir: reliability-engineering
-            args:
-              - -c
-              - |
-                set -eu
-                cd ../reliability-engineering-bundled
-                cf login -a $CF_API -u $CF_USER -p $CF_PASS -o $CF_ORG -s $CF_SPACE
-                cf push -f manifest.yml reliability-engineering
-
+          run: *deploy


### PR DESCRIPTION
A few of the document repos deploy and bundle in the same way. Use yml anchors to tidy and reduce the amount of code.

Single: @matthewcullum-gds