### PR TITLE
Make volume size for workers configurable per tenant

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-worker-pool/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/launch-template.tf
@@ -38,7 +38,7 @@ resource "aws_launch_template" "concourse_worker" {
     device_name = "/dev/sda1"
 
     ebs {
-      volume_size = 50
+      volume_size = "${var.volume_size}"
     }
   }
 

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/variables.tf
@@ -46,8 +46,12 @@ variable "instance_type" {
   default = "t3.small"
 }
 
+variable "volume_size" {
+  default = 50
+}
+
 variable "additional_concourse_worker_iam_policies" {
-  type = "list"
+  type    = "list"
   default = []
 }
 


### PR DESCRIPTION
Default to 50GB

Co-authored-by: @tlwr <toby.lornewelch-richards@digital.cabinet-office.gov.uk>