### PR TITLE
Generate per-team local user

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-keys/local-users.tf
+++ b/reliability-engineering/terraform/modules/concourse-keys/local-users.tf
@@ -8,7 +8,7 @@ output "local_user_passwords" {
   value = "${
     zipmap(
       var.worker_team_names,
-      random_string.local_user_password
+      random_string.local_user_password.*.result
     )
   }"
 }

--- a/reliability-engineering/terraform/modules/concourse-keys/local-users.tf
+++ b/reliability-engineering/terraform/modules/concourse-keys/local-users.tf
@@ -1,0 +1,14 @@
+resource "random_string" "local_user_password" {
+  count = "${length(var.worker_team_names)}"
+
+  length  = 32
+}
+
+output "local_user_passwords" {
+  value = "${
+    zipmap(
+      var.worker_team_names,
+      random_string.local_user_password
+    )
+  }"
+}

--- a/reliability-engineering/terraform/modules/concourse-keys/local-users.tf
+++ b/reliability-engineering/terraform/modules/concourse-keys/local-users.tf
@@ -4,6 +4,20 @@ resource "random_string" "local_user_password" {
   length  = 32
 }
 
+resource "aws_ssm_parameter" "concourse_local_usernames_and_passwords" {
+  count = "${length(var.worker_team_names)}"
+
+  name        = "/${var.deployment}/concourse/pipelines/${element(var.worker_team_names, count.index)}/local_user_password"
+  type        = "SecureString"
+  description = "Password for the local user with admin access to team ${element(var.worker_team_names, count.index)}"
+  value       = "${element(random_string.local_user_password.*.result, count.index)}"
+  key_id      = "${aws_kms_key.concourse_worker_shared.key_id}"
+
+  tags = {
+    Deployment = "${var.deployment}"
+  }
+}
+
 output "local_user_passwords" {
   value = "${
     zipmap(

--- a/reliability-engineering/terraform/modules/concourse-keys/local-users.tf
+++ b/reliability-engineering/terraform/modules/concourse-keys/local-users.tf
@@ -1,6 +1,7 @@
 resource "random_string" "local_user_password" {
   count = "${length(var.worker_team_names)}"
 
+  special = false
   length  = 32
 }
 

--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -110,7 +110,7 @@ ExecStart=/usr/local/bin/concourse web \
   \
   --peer-url http://$${local_ip}:8080 \
   \
-  --add-local-user $${local_users} \
+  $(jq -r 'to_entries | map("--add-local-user \(.key):\(.value)") | join(" ")' <<< $local_users) \
   --main-team-local-user=main \
 
 Type=simple

--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -103,6 +103,8 @@ ExecStart=/usr/local/bin/concourse web \
   --prometheus-bind-port 9391    \
   \
   --peer-url http://$${local_ip}:8080 \
+  \
+  --add-local-user ${local_users} \
 
 Type=simple
 RestartSec=3s

--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -44,6 +44,12 @@ postgres_password="$(
     --with-decryption \
   | jq -r .Parameter.Value
 )"
+local_users="$(
+  aws ssm get-parameter \
+    --name /${deployment}/concourse/web/local_users \
+    --with-decryption \
+  | jq -r .Parameter.Value
+)"
 
 aws ssm get-parameter \
   --name /${deployment}/concourse/web/ssh_key \
@@ -104,7 +110,7 @@ ExecStart=/usr/local/bin/concourse web \
   \
   --peer-url http://$${local_ip}:8080 \
   \
-  --add-local-user ${local_users} \
+  --add-local-user $${local_users} \
 
 Type=simple
 RestartSec=3s

--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -111,6 +111,7 @@ ExecStart=/usr/local/bin/concourse web \
   --peer-url http://$${local_ip}:8080 \
   \
   --add-local-user $${local_users} \
+  --main-team-local-user=main \
 
 Type=simple
 RestartSec=3s

--- a/reliability-engineering/terraform/modules/concourse-web/keys.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/keys.tf
@@ -38,7 +38,7 @@ resource "aws_ssm_parameter" "concourse_web_local_users" {
   name        = "/${var.deployment}/concourse/web/local_users"
   type        = "SecureString"
   description = "Usernames and passwords for local users"
-  value       = "${local.usernames_and_passwords}"
+  value       = "${jsonencode(var.local_user_passwords)}"
   key_id      = "${var.web_kms_key_id}"
 
   tags = {

--- a/reliability-engineering/terraform/modules/concourse-web/keys.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/keys.tf
@@ -34,6 +34,18 @@ resource "aws_ssm_parameter" "concourse_web_db_password" {
   }
 }
 
+resource "aws_ssm_parameter" "concourse_web_local_users" {
+  name        = "/${var.deployment}/concourse/web/local_users"
+  type        = "SecureString"
+  description = "Usernames and passwords for local users"
+  value       = "${local.usernames_and_passwords}"
+  key_id      = "${var.web_kms_key_id}"
+
+  tags = {
+    Deployment = "${var.deployment}"
+  }
+}
+
 resource "aws_s3_bucket_object" "concourse_web_team_authorized_worker_keys" {
   bucket  = "${aws_s3_bucket.concourse_web.bucket}"
   key     = "team_authorized_worker_keys.json"

--- a/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
@@ -10,6 +10,14 @@ data "aws_ami" "ubuntu_bionic" {
   }
 }
 
+locals {
+  usernames_and_passwords = "${join(",", formatlist(
+    "%s:%s",
+    keys(var.local_user_passwords),
+    values(var.local_user_passwords),
+  ))}"
+}
+
 data "template_file" "concourse_web_cloud_init" {
   template = "${file("${path.module}/files/web-init.sh")}"
 
@@ -23,6 +31,8 @@ data "template_file" "concourse_web_cloud_init" {
 
     concourse_web_bucket      = "${aws_s3_bucket.concourse_web.bucket}"
     worker_keys_s3_object_key = "${aws_s3_bucket_object.concourse_web_team_authorized_worker_keys.id}"
+
+    local_users = "${local.usernames_and_passwords}"
   }
 }
 

--- a/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
@@ -31,8 +31,6 @@ data "template_file" "concourse_web_cloud_init" {
 
     concourse_web_bucket      = "${aws_s3_bucket.concourse_web.bucket}"
     worker_keys_s3_object_key = "${aws_s3_bucket_object.concourse_web_team_authorized_worker_keys.id}"
-
-    local_users = "${local.usernames_and_passwords}"
   }
 }
 

--- a/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
@@ -10,14 +10,6 @@ data "aws_ami" "ubuntu_bionic" {
   }
 }
 
-locals {
-  usernames_and_passwords = "${join(",", formatlist(
-    "%s:%s",
-    keys(var.local_user_passwords),
-    values(var.local_user_passwords),
-  ))}"
-}
-
 data "template_file" "concourse_web_cloud_init" {
   template = "${file("${path.module}/files/web-init.sh")}"
 

--- a/reliability-engineering/terraform/modules/concourse-web/security-groups.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/security-groups.tf
@@ -104,6 +104,16 @@ resource "aws_security_group_rule" "concourse_lb_ingress_from_outside_80" {
   cidr_blocks       = ["${var.whitelisted_cidr_blocks}"]
 }
 
+resource "aws_security_group_rule" "concourse_lb_ingress_from_workers_443" {
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 443
+  to_port   = 443
+
+  security_group_id = "${aws_security_group.concourse_lb.id}"
+  cidr_blocks       = ["${formatlist("%s/32", var.worker_pool_egress_eips)}"]
+}
+
 resource "aws_security_group_rule" "concourse_web_egress_to_outside" {
   type      = "egress"
   protocol  = "all"

--- a/reliability-engineering/terraform/modules/concourse-web/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/variables.tf
@@ -41,6 +41,11 @@ variable "local_user_passwords" {
   type        = "map"
 }
 
+variable "worker_pool_egress_eips" {
+  type        = "list"
+  description = "A list of all of the egress IPs of all of the worker pools"
+}
+
 variable "worker_ssh_public_keys_openssh" {
   type = "map"
 }

--- a/reliability-engineering/terraform/modules/concourse-web/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/variables.tf
@@ -36,6 +36,11 @@ variable "worker_team_names" {
   type        = "list"
 }
 
+variable "local_user_passwords" {
+  description = "The map of team to generated password, used for local users."
+  type        = "map"
+}
+
 variable "worker_ssh_public_keys_openssh" {
   type = "map"
 }


### PR DESCRIPTION
## What

We need to be able to allow the access to concourse from different
services.

The current use case, is that Concourse task will need to interact with
it's own API to allow pipeline setting to achieve self-updating
pipelines.

## How to review

- Sanity check
