### PR TITLE
Make the internal-apps pipeline visible to everyone

### DIFF
--- a/reliability-engineering/pipelines/internal-apps.yml
+++ b/reliability-engineering/pipelines/internal-apps.yml
@@ -43,6 +43,7 @@ resources:
 
 jobs:
   - name: build-re-team-manual
+    public: true
     serial: true
     plan:
       - get: re-team-manual-git
@@ -79,6 +80,7 @@ jobs:
           path: bundled
 
   - name: build-reliability-engineering
+    public: true
     serial: true
     plan:
       - get: reliability-engineering-git
@@ -105,6 +107,7 @@ jobs:
           path: bundled
 
   - name: build-gds-way
+    public: true
     serial: true
     plan:
       - get: gds-way-git
@@ -131,6 +134,7 @@ jobs:
           path: bundled
 
   - name: build-re-request-an-aws-account
+    public: true
     serial: true
     plan:
       - get: re-request-an-aws-account-git


### PR DESCRIPTION
- These are RE and in some cases GDS-wide apps, so it makes sense for
  everyone with access to view Concourse (logged in or not) to be able to
  see the builds.
- This works in tandem with `fly -t autom8 expose-pipeline -p
  internal-apps`, which I've run.