### PR TITLE
Use the `bundle-pr` anchor only when building PRs

### DIFF
--- a/reliability-engineering/pipelines/internal-apps.yml
+++ b/reliability-engineering/pipelines/internal-apps.yml
@@ -103,7 +103,7 @@ jobs:
           inputs:
             - name: re-team-manual-pr
               path: repo
-          run: &bundle
+          run: &bundle-pr
             path: sh
             dir: repo
             args:
@@ -144,7 +144,7 @@ jobs:
               path: repo
           outputs:
             - name: bundled
-          run: &bundle-pr
+          run: &bundle
             path: sh
             dir: repo
             args:


### PR DESCRIPTION
- This was the wrong way around, causing the gds-way master builds to fail to deploy (they use the `&bundle-pr` and `&bundle` YAML anchors) because PR builds don't copy files around, they just run tests.