### PR TITLE
Create a GDSSecurityAudit IAM Role 

### DIFF
--- a/cyber-security/modules/gds_security_audit_role/gds_security_audit_role.tf
+++ b/cyber-security/modules/gds_security_audit_role/gds_security_audit_role.tf
@@ -1,0 +1,19 @@
+data "template_file" "trust" {
+  template = "${file("${path.module}/json/trust.json")}"
+
+  vars {
+    prefix            = "${var.prefix}"
+    chain_account_id  = "${var.chain_account_id}"
+  }
+}
+
+resource "aws_iam_role" "gds_security_audit_role" {
+  name = "${var.prefix}GDSSecurityAudit"
+
+  assume_role_policy = "${data.template_file.trust.rendered}"
+}
+
+resource "aws_iam_role_policy_attachment" "gds_security_audit_role_policy_attachment" {
+  role       = "${aws_iam_role.gds_security_audit_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+}

--- a/cyber-security/modules/gds_security_audit_role/json/trust.json
+++ b/cyber-security/modules/gds_security_audit_role/json/trust.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+            "arn:aws:iam::${chain_account_id}:role/${prefix}GDSSecurityAuditChain"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/cyber-security/modules/gds_security_audit_role/output.tf
+++ b/cyber-security/modules/gds_security_audit_role/output.tf
@@ -1,0 +1,11 @@
+output "role_id" {
+  value = "${aws_iam_role.gds_security_audit_role.id}"
+}
+
+output "role_arn" {
+  value = "${aws_iam_role.gds_security_audit_role.arn}"
+}
+
+output "role_name" {
+  value = "${aws_iam_role.gds_security_audit_role.name}"
+}

--- a/cyber-security/modules/gds_security_audit_role/variables.tf
+++ b/cyber-security/modules/gds_security_audit_role/variables.tf
@@ -1,0 +1,8 @@
+# This should be left to default to an empty string outside the Cyber Security team
+variable "prefix" {
+  default = ""
+}
+
+# This is the AWS account ID for the billing account.
+# Ask tech-ops if you're unsure.
+variable "chain_account_id" {}


### PR DESCRIPTION
implementing the SecurityAudit canned policy and trusting the GDSSecurityAuditChain role defined in a central organisation account.