### PR TITLE
Security audit role inline policies

### DIFF
--- a/cyber-security/modules/gds_security_audit_role/inline_policies.tf
+++ b/cyber-security/modules/gds_security_audit_role/inline_policies.tf
@@ -1,0 +1,27 @@
+data "aws_iam_policy_document" "support_inline_policy_document" {
+  statement {
+    effect    = "Allow"
+    actions   = ["support:*"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "support_inline_policy" {
+  name    = "${var.prefix}GDSSecurityAuditInlineSupportPolicy"
+  role    = "${aws_iam_role.gds_security_audit_role.id}"
+  policy  = "${data.aws_iam_policy_document.support_inline_policy_document.json}"
+}
+
+data "aws_iam_policy_document" "sts_inline_policy_document" {
+  statement {
+    effect    = "Allow"
+    actions   = ["sts:GetCallerIdentity"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "sts_inline_policy" {
+  name    = "${var.prefix}GDSSecurityAuditInlineSupportPolicy"
+  role    = "${aws_iam_role.gds_security_audit_role.id}"
+  policy  = "${data.aws_iam_policy_document.sts_inline_policy_document.json}"
+}

--- a/cyber-security/modules/gds_security_audit_role/inline_policies.tf
+++ b/cyber-security/modules/gds_security_audit_role/inline_policies.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "sts_inline_policy_document" {
 }
 
 resource "aws_iam_role_policy" "sts_inline_policy" {
-  name    = "${var.prefix}GDSSecurityAuditInlineSupportPolicy"
+  name    = "${var.prefix}GDSSecurityAuditInlineSTSPolicy"
   role    = "${aws_iam_role.gds_security_audit_role.id}"
   policy  = "${data.aws_iam_policy_document.sts_inline_policy_document.json}"
 }

--- a/cyber-security/modules/gds_security_audit_role/inline_policies.tf
+++ b/cyber-security/modules/gds_security_audit_role/inline_policies.tf
@@ -1,7 +1,7 @@
 data "aws_iam_policy_document" "support_inline_policy_document" {
   statement {
     effect    = "Allow"
-    actions   = ["support:*"]
+    actions   = ["support:Describe*"]
     resources = ["*"]
   }
 }


### PR DESCRIPTION
Unfortunately the canned SecurityAudit policy does not include the support endpoint which is required for getting Trusted Advisor check results. We've added this as an inline policy, checked the rest of the policy statements from the existing csw-client-role repo to ensure there's nothing else missing and also added an inline policy to explicitly allow sts:GetCallerIdentity. 

We've also raised a support ticket with AWS to understand why these permissions are not in the SecurityAudit policy. 