### PR TITLE
Remove unused ssh submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "reliability-engineering/bosh/modules/jumpbox-deployment"]
-	path = reliability-engineering/bosh/modules/jumpbox-deployment
-	url = git@github.com:cloudfoundry/jumpbox-deployment.git


### PR DESCRIPTION
This was causing the aws-user-management-account-users to fail to clone
because the job does not have an ssh key

Signed-off-by: Toby Lorne <toby.lornewelch-richards@digital.cabinet-office.gov.uk>