### PR TITLE
Fix support IAM permissions

### DIFF
--- a/cyber-security/modules/gds_security_audit_role/inline_policies.tf
+++ b/cyber-security/modules/gds_security_audit_role/inline_policies.tf
@@ -1,7 +1,7 @@
 data "aws_iam_policy_document" "support_inline_policy_document" {
   statement {
     effect    = "Allow"
-    actions   = ["support:Describe*"]
+    actions   = ["support:*"]
     resources = ["*"]
   }
 }


### PR DESCRIPTION
```
data "aws_iam_policy_document" "support_inline_policy_document" {
  statement {
    effect    = "Allow"
    actions   = ["support:*"]
    resources = ["*"]
  }
}
```

https://github.com/alphagov/tech-ops/pull/26
> Shouldn't this be support:Describe*?

```
+   actions   = ["support:Describe*"]
-   actions   = ["support:*"]
```

>cloud-security-watch - ERROR - An error occurred (AccessDeniedException) when calling the DescribeTrustedAdvisorCheckResult operation: User: arn:aws:sts::489877524855:assumed-role/StagingGDSSecurityAudit/489877524855-StagingGDSSecurityAudit is not authorized to perform: support:

https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssupport.html
>AWS Support does not let you allow or deny access to individual actions; therefore your policy must use the "Action": "support:*" to use the AWS Support Center or to use the AWS Support API. In addition, when you use the AWS Support API to call Trusted Advisor-related actions (such as DescribeTrustedAdvisorChecks), none of the trustedadvisor actions restrict your access. The trustedadvisor actions apply only to Trusted Advisor in the AWS Management Console

:sob: :sob: :sob: