### PR TITLE
Set PostgreSQL Engine Version for Concourse Grafana RDS instances

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
@@ -41,6 +41,7 @@ resource "aws_db_instance" "concourse_grafana_db" {
   allocated_storage         = 25
   storage_type              = "gp2"
   engine                    = "postgres"
+  engine_version            = "10.9"
   instance_class            = "db.t2.small"
   name                      = "grafana"
   username                  = "grafana"


### PR DESCRIPTION
- Like #29, but I didn't realise this was separate.