### PR TITLE
Use the Ruby 2.6.3 Docker image for re-request-an-aws-account jobs

### DIFF
--- a/reliability-engineering/pipelines/internal-apps.yml
+++ b/reliability-engineering/pipelines/internal-apps.yml
@@ -303,8 +303,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: gdsre/aws-ruby
-              tag: 2.6.1-3.0.1
+              repository: ruby
+              tag: 2.6.3
           inputs:
             - name: re-request-an-aws-account-pr
               path: repo
@@ -342,8 +342,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: gdsre/aws-ruby
-              tag: 2.6.1-3.0.1
+              repository: ruby
+              tag: 2.6.3
           inputs:
             - name: re-request-an-aws-account-git
               path: repo


### PR DESCRIPTION
- The version had been upgraded in
  https://github.com/alphagov/re-request-an-aws-account/pull/42, but we
  didn't make a new `gdsre/aws-ruby` Docker image. This isn't Verify, so
  we can use the main Ruby Docker image rather than rolling our own.