### PR TITLE
REP: Upgrade multi-tenant concourse

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -12,15 +12,15 @@ echo "Installing dependences"
 apt-get install --yes jq awscli
 
 echo "Downloading concourse binaries"
-concourse_url="https://github.com/concourse/concourse/releases/download/${concourse_version}/concourse_linux_amd64"
+concourse_archive="concourse-${concourse_version}-linux-amd64.tgz"
+concourse_url="https://github.com/concourse/concourse/releases/download/v${concourse_version}/$concourse_archive"
 cd /tmp
-echo '${concourse_sha1}' > concourse_linux_amd64.sha1
-curl -L --silent --fail "$concourse_url" > concourse_linux_amd64
-sha1sum -c concourse_linux_amd64.sha1
+echo '${concourse_sha1}' > concourse.sha1
+curl -L --silent --fail "$concourse_url" > "$concourse_archive"
+sha1sum -c concourse.sha1
 echo "Concourse binaries ok and pass checksum"
+tar -xvf "$concourse_archive" -C /usr/local
 cd -
-mv /tmp/concourse_linux_amd64 /usr/local/bin/concourse
-chmod +x /usr/local/bin/concourse
 
 echo "Configuring concourse"
 mkdir -p /opt/concourse/keys

--- a/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
@@ -18,8 +18,8 @@ data "template_file" "concourse_web_cloud_init" {
     main_team_github_team    = "${var.main_team_github_team}"
     concourse_external_url   = "${aws_route53_record.concourse_public_deployment.fqdn}"
     concourse_db_url         = "${aws_route53_record.concourse_private_db.fqdn}"
-    concourse_version        = "v4.2.3"
-    concourse_sha1           = "746ee3c83567924f56faf5c85131b996a442542c  concourse_linux_amd64"
+    concourse_version        = "5.4.1"
+    concourse_sha1           = "cab2346fd607e863eeb0d8f990a0bba79916166e  concourse-5.4.1-linux-amd64.tgz"
 
     concourse_web_bucket      = "${aws_s3_bucket.concourse_web.bucket}"
     worker_keys_s3_object_key = "${aws_s3_bucket_object.concourse_web_team_authorized_worker_keys.id}"

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
@@ -12,15 +12,15 @@ echo "Installing dependences"
 apt-get install --yes jq awscli
 
 echo "Downloading concourse binaries"
-concourse_url="https://github.com/concourse/concourse/releases/download/${concourse_version}/concourse_linux_amd64"
+concourse_archive="concourse-${concourse_version}-linux-amd64.tgz"
+concourse_url="https://github.com/concourse/concourse/releases/download/v${concourse_version}/$concourse_archive"
 cd /tmp
-echo '${concourse_sha1}' > concourse_linux_amd64.sha1
-curl -L --silent --fail "$concourse_url" > concourse_linux_amd64
-sha1sum -c concourse_linux_amd64.sha1
+echo '${concourse_sha1}' > concourse.sha1
+curl -L --silent --fail "$concourse_url" > "$concourse_archive"
+sha1sum -c concourse.sha1
 echo "Concourse binaries ok and pass checksum"
+tar -xvf "$concourse_archive" -C /usr/local
 cd -
-mv /tmp/concourse_linux_amd64 /usr/local/bin/concourse
-chmod +x /usr/local/bin/concourse
 
 echo "Configuring concourse"
 mkdir -p /opt/concourse/keys
@@ -42,7 +42,7 @@ Description=concourse-worker
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/concourse worker \
+ExecStart=/usr/local/concourse/bin/concourse worker \
   --work-dir /opt/concourse/worker \
   --tsa-host ${concourse_host}:2222 \
   --tsa-public-key /opt/concourse/keys/web_pub_key \

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/launch-template.tf
@@ -18,8 +18,8 @@ data "template_file" "concourse_worker_cloud_init" {
     worker_team_name = "${var.name}"
 
     concourse_host    = "${local.concourse_url}"
-    concourse_version = "v4.2.3"
-    concourse_sha1    = "746ee3c83567924f56faf5c85131b996a442542c  concourse_linux_amd64"
+    concourse_version = "5.4.1"
+    concourse_sha1           = "cab2346fd607e863eeb0d8f990a0bba79916166e  concourse-5.4.1-linux-amd64.tgz"
   }
 }
 


### PR DESCRIPTION
- The packaging format between concourse 4/5 is different to unpack it
  slightly differently
- As such, the filename, shasum, download location etc. have also
  changed slightly
- This is mostly cribbed from doing the same upgrade to Verify concourse
  so it should work (that was to 5.3.0 but should be the same)