### PR TITLE
REP: Use correct peer address

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -89,6 +89,7 @@ ExecStart=/usr/local/concourse/bin/concourse web \
   --session-signing-key /opt/concourse/keys/web_session \
   \
   --external-url https://${concourse_external_url} \
+  --peer-address $${local_ip}                      \
   \
   --aws-ssm-region eu-west-2 \
   --aws-ssm-pipeline-secret-template \


### PR DESCRIPTION
- We took this out as it worked on a single node
- Moving to HA web nodes, we do need this address to be correct
- Removing the http seems to fix it for N web nodes (tested when N=2)