### PR TITLE
cache concourse credentials for 5 minutes

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -122,6 +122,9 @@ MemoryLimit=infinity
 LimitNPROC=infinity
 LimitNOFILE=infinity
 
+Environment=CONCOURSE_SECRET_CACHE_ENABLED=true
+Environment=CONCOURSE_SECRET_CACHE_DURATION=5m
+
 [Install]
 WantedBy=multi-user.target
 EOF


### PR DESCRIPTION
We upgraded to concourse 5.  This means we can now enable the
credential caching feature which (I hope) will fix the parameter store
rate limits we've been hitting.