### PR TITLE
BAU: Fix internal app deploys

### DIFF
--- a/reliability-engineering/pipelines/internal-apps.yml
+++ b/reliability-engineering/pipelines/internal-apps.yml
@@ -154,7 +154,8 @@ jobs:
               apt-get install -y nodejs
               bundle install --without development
               bundle exec middleman build
-              cp -r . ../bundled/
+              cp manifest.yml ../bundled/manifest.yml
+              cp -r build/* ../bundled/
       - put: deploy-to-paas-docs-space
         params:
           manifest: bundled/manifest.yml


### PR DESCRIPTION
- The Concourse v5.4.1 upgrade updated the CF resource that is baked
  into Concourse
- The upgraded version now fully overrides the `path` in the manifest
  rather than path just being the working directory so copy the
generated files straight into bundled
- The staticfile buildpack ignores the manifest.yml file so won't serve
  it to users