### PR TITLE
Fix gds-way deploy

### DIFF
--- a/reliability-engineering/pipelines/internal-apps.yml
+++ b/reliability-engineering/pipelines/internal-apps.yml
@@ -282,6 +282,7 @@ jobs:
           run: *bundle
       - put: deploy-to-paas-docs-space
         params:
+          current_app_name: gds-way
           manifest: bundled/manifest.yml
           show_app_log: true
           path: bundled


### PR DESCRIPTION
- GDS way has a manifest with mulitple apps
- Since the Concourse upgrade we need to specify the app we are
  deploying
- Decided not to deploy the redirect app anymore as it never changes