### PR TITLE
use a more descriptive log group name for web logs

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -165,7 +165,7 @@ cat <<EOF > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 				"collect_list": [
 					{
 						"file_path": "/var/log/syslog",
-						"log_group_name": "/aws/ec2/syslog",
+						"log_group_name": "/${deployment}/concourse/web",
 						"log_stream_name": "{hostname}/syslog",
 						"timestamp_format" :"%b %d %H:%M:%S"
 					}


### PR DESCRIPTION
## What

usee a log group name that is more descriptive of the deployment
and actor in the form `/{deployment}/concourse/{app}`

## Why

So we can tell the difference between staging and prod deployments, and only ship logs from one of them