### PR TITLE
Output the concourse web log group name.

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -165,7 +165,7 @@ cat <<EOF > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 				"collect_list": [
 					{
 						"file_path": "/var/log/syslog",
-						"log_group_name": "/${deployment}/concourse/web",
+						"log_group_name": "${concourse_web_syslog_log_group_name}",
 						"log_stream_name": "{hostname}/syslog",
 						"timestamp_format" :"%b %d %H:%M:%S"
 					}

--- a/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
@@ -23,7 +23,13 @@ data "template_file" "concourse_web_cloud_init" {
 
     concourse_web_bucket      = "${aws_s3_bucket.concourse_web.bucket}"
     worker_keys_s3_object_key = "${aws_s3_bucket_object.concourse_web_team_authorized_worker_keys.id}"
+
+    concourse_web_syslog_log_group_name = "${local.concourse_web_syslog_log_group_name}"
   }
+}
+
+output "concourse_web_syslog_log_group_name" {
+  value = "${local.concourse_web_syslog_log_group_name}"
 }
 
 resource "aws_launch_template" "concourse_web" {

--- a/reliability-engineering/terraform/modules/concourse-web/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/variables.tf
@@ -95,3 +95,7 @@ variable "db_storage_gb" {
 }
 
 data "aws_caller_identity" "account" {}
+
+locals {
+  concourse_web_syslog_log_group_name = "/${var.deployment}/concourse/web"
+}


### PR DESCRIPTION
For upstream consumption (e.g. for connecting with kinesis). Also includes
a little refactoring to DRY up the name of the log group.