### PR TITLE
BAU: Upgrade to concourse 5.6.0

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
@@ -18,8 +18,8 @@ data "template_file" "concourse_web_cloud_init" {
     main_team_github_team  = "${var.main_team_github_team}"
     concourse_external_url = "${aws_route53_record.concourse_public_deployment.fqdn}"
     concourse_db_url       = "${aws_route53_record.concourse_private_db.fqdn}"
-    concourse_version      = "5.4.1"
-    concourse_sha1         = "cab2346fd607e863eeb0d8f990a0bba79916166e  concourse-5.4.1-linux-amd64.tgz"
+    concourse_version      = "5.6.0"
+    concourse_sha1         = "8833a6d2f3c3af0025220b9cec31a0f39ace9fc5  concourse-5.6.0-linux-amd64.tgz"
 
     concourse_web_bucket      = "${aws_s3_bucket.concourse_web.bucket}"
     worker_keys_s3_object_key = "${aws_s3_bucket_object.concourse_web_team_authorized_worker_keys.id}"

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/launch-template.tf
@@ -18,8 +18,8 @@ data "template_file" "concourse_worker_cloud_init" {
     worker_team_name = "${var.name}"
 
     concourse_host    = "${local.concourse_url}"
-    concourse_version = "5.4.1"
-    concourse_sha1    = "cab2346fd607e863eeb0d8f990a0bba79916166e  concourse-5.4.1-linux-amd64.tgz"
+    concourse_version = "5.6.0"
+    concourse_sha1    = "8833a6d2f3c3af0025220b9cec31a0f39ace9fc5  concourse-5.6.0-linux-amd64.tgz"
   }
 }
 


### PR DESCRIPTION
- Firebreak seems like a good time for a version upgrade
- Resource version pinning is handy - let's get access to it