### PR TITLE
remove timestamp parsing from cloudwatch agent in concourse

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -166,8 +166,7 @@ cat <<EOF > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 					{
 						"file_path": "/var/log/syslog",
 						"log_group_name": "${concourse_web_syslog_log_group_name}",
-						"log_stream_name": "{hostname}/syslog",
-						"timestamp_format" :"%b %d %H:%M:%S"
+						"log_stream_name": "{hostname}/syslog"
 					}
 				]
 			}


### PR DESCRIPTION
cloudwatch log agent is very particular about it's timestamps, if it
fails to parse a log line it will default to some kind of epoch or old
date and stop shipping logs it tihnks they are "older than 14 days"

removing the timetstamp format from the config means that the current
time is always used, which is good enough for our use case.