### PR TITLE
Allow SSH provisioning, restrict agents to Ireland

### DIFF
--- a/reliability-engineering/terraform/modules/web-page-test-cluster/ec2.tf
+++ b/reliability-engineering/terraform/modules/web-page-test-cluster/ec2.tf
@@ -22,7 +22,21 @@ resource "aws_security_group" "web_page_test_controller" {
     from_port   = 0
     to_port     = 0
     protocol    = -1
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.ingress_cidrs}"]
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["${aws_vpc.main.cidr_block}"]
+  }
+
+  ingress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = -1
+    security_groups = ["${aws_security_group.web_page_test_controller_lb.id}"]
   }
 
   egress {
@@ -78,17 +92,20 @@ data "aws_ssm_parameter" "web_page_test_google_oauth_client_secret" {
 }
 
 resource "random_string" "api_key" {
-  length           = 20
-  number           = false
-  special          = false
-  upper            = false
+  length  = 20
+  number  = false
+  special = false
+  upper   = false
 }
 
 resource "aws_instance" "web_page_test_controller" {
   ami           = "${local.ami_id}"
   instance_type = "t2.micro"
-  subnet_id     = "${aws_subnet.private.id}"
-  private_ip    = "10.0.10.100"              # Arbitrarily selected
+  subnet_id     = "${aws_subnet.public.0.id}"
+  private_ip    = "10.0.1.100"                                        # Arbitrarily selected
+  key_name      = "${aws_key_pair.web_page_test_controller.key_name}"
+
+  associate_public_ip_address = true
 
   vpc_security_group_ids = [
     "${aws_security_group.web_page_test_controller.id}",
@@ -169,5 +186,31 @@ resource "aws_route53_record" "web_page_test" {
     name                   = "${aws_lb.web_page_test_controller.dns_name}"
     zone_id                = "${aws_lb.web_page_test_controller.zone_id}"
     evaluate_target_health = false
+  }
+}
+
+resource "null_resource" "web_page_test_controller_provisioning" {
+  connection {
+    type        = "ssh"
+    user        = "ubuntu"
+    host        = "${aws_instance.web_page_test_controller.public_ip}"
+    private_key = "${tls_private_key.web_page_test_controller.private_key_pem}"
+  }
+
+  triggers = {
+    locations_ini_content = "${sha1(file("${path.module}/files/ec2_locations.ini"))}"
+    instance_id = "${aws_instance.web_page_test_controller.id}"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/files/ec2_locations.ini"
+    destination = "/tmp/ec2_locations.ini"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/ec2_locations.ini /var/www/webpagetest/www/settings/ec2_locations.ini",
+      "sudo chown www-data:www-data /var/www/webpagetest/www/settings/ec2_locations.ini",
+    ]
   }
 }

--- a/reliability-engineering/terraform/modules/web-page-test-cluster/files/ec2_locations.ini
+++ b/reliability-engineering/terraform/modules/web-page-test-cluster/files/ec2_locations.ini
@@ -1,0 +1,54 @@
+[locations]
+1=eu-west-1-group
+2=eu-west-1-linux-group
+default=eu-west-1-group
+
+[eu-west-1-group]
+1=eu-west-1
+2=eu-west-1_IE11
+3=eu-west-1_IE10
+4=eu-west-1_IE9
+label="Europe (Ireland)"
+lat=53.343583
+lng=-6.267014
+default=eu-west-1
+
+[eu-west-1]
+browser=Chrome,Firefox
+label="Europe (Ireland)"
+region=eu-west-1
+ami=ami-03009a026570febbb
+size=c4.large
+
+[eu-west-1_IE11]
+browser=IE 11
+label="Europe (Ireland)"
+region=eu-west-1
+ami=ami-03009a026570febbb
+size=c4.large
+
+[eu-west-1_IE10]
+browser=IE 10
+label="Europe (Ireland)"
+region=eu-west-1
+ami=ami-3b45f048
+
+[eu-west-1_IE9]
+browser=IE 9
+label="Europe (Ireland)"
+region=eu-west-1
+ami=ami-2d5fea5e
+
+[eu-west-1-linux-group]
+1=eu-west-1-linux
+label="Europe - Linux (Ireland)"
+lat=53.343583
+lng=-6.267014
+default=eu-west-1-linux
+
+[eu-west-1-linux]
+browser=Chrome,Chrome Beta,Chrome Canary,Firefox,Firefox Nightly,Firefox ESR
+label="Europe - Linux (Ireland)"
+region=eu-west-1
+ami=ami-05e797bb427383997
+size=c4.large

--- a/reliability-engineering/terraform/modules/web-page-test-cluster/keys.tf
+++ b/reliability-engineering/terraform/modules/web-page-test-cluster/keys.tf
@@ -1,0 +1,9 @@
+resource "tls_private_key" "web_page_test_controller" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "aws_key_pair" "web_page_test_controller" {
+  key_name   = "${var.env}-controller"
+  public_key = "${tls_private_key.web_page_test_controller.public_key_openssh}"
+}


### PR DESCRIPTION
What
----

We want to modify the contents of ec2_locations.ini so we can restrict
the locations just to Ireland, otherwise the queue gets filled with
tests that cannot run, and instances are spun up in regions we have no
visibility over.

In order to provision the controller we need to:

- Move it into a public subnet so it is routable
- Now it is routable, lock down ingress to the LB and the VPN

Set up a null resource which will update the configuration of the
instance when ec2_locations.ini changes

Related work
----

See https://github.com/alphagov/tech-ops-private/pull/135

Who can review
----

Done as pair with @Nooshu 