### PR TITLE
Add permissions for Concourse's S3 management

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
@@ -73,6 +73,7 @@ resource "aws_iam_policy" "concourse_worker_base" {
           "s3:DeleteObjectTagging",
           "s3:DeleteObjectVersion",
           "s3:DeleteObjectVersionTagging",
+          "s3:GetBucketVersioning",
           "s3:GetObject",
           "s3:GetObjectAcl",
           "s3:GetObjectTagging",


### PR DESCRIPTION
Some of the resources, require us to be able to read the Bucket
Versioning for checking purposes.

This is currently affecting Notify but perhaps could be affecting others
as well.