### PR TITLE
Add GetBucketVersioning to Concourse worker role

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
@@ -73,6 +73,7 @@ resource "aws_iam_policy" "concourse_worker_base" {
           "s3:DeleteObjectTagging",
           "s3:DeleteObjectVersion",
           "s3:DeleteObjectVersionTagging",
+          "GetBucketVersioning",
           "s3:GetObject",
           "s3:GetObjectAcl",
           "s3:GetObjectTagging",


### PR DESCRIPTION
What
---

When people are using versioned files in buckets they need to use the GetBucketVersioning API endpoint

Who can review
---

@paroxp 