### PR TITLE
Bump Concourse version to 5.7.0

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
@@ -18,8 +18,8 @@ data "template_file" "concourse_web_cloud_init" {
     main_team_github_team  = "${var.main_team_github_team}"
     concourse_external_url = "${aws_route53_record.concourse_public_deployment.fqdn}"
     concourse_db_url       = "${aws_route53_record.concourse_private_db.fqdn}"
-    concourse_version      = "5.6.0"
-    concourse_sha1         = "8833a6d2f3c3af0025220b9cec31a0f39ace9fc5  concourse-5.6.0-linux-amd64.tgz"
+    concourse_version      = "5.7.0"
+    concourse_sha1         = "2ed57a17149ac8a2cdb3d38f7d6d70b86d11c449  concourse-5.7.0-linux-amd64.tgz"
 
     concourse_web_bucket      = "${aws_s3_bucket.concourse_web.bucket}"
     worker_keys_s3_object_key = "${aws_s3_bucket_object.concourse_web_team_authorized_worker_keys.id}"

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/launch-template.tf
@@ -18,8 +18,8 @@ data "template_file" "concourse_worker_cloud_init" {
     worker_team_name = "${var.name}"
 
     concourse_host    = "${local.concourse_url}"
-    concourse_version = "5.6.0"
-    concourse_sha1    = "8833a6d2f3c3af0025220b9cec31a0f39ace9fc5  concourse-5.6.0-linux-amd64.tgz"
+    concourse_version = "5.7.0"
+    concourse_sha1    = "2ed57a17149ac8a2cdb3d38f7d6d70b86d11c449  concourse-5.7.0-linux-amd64.tgz"
   }
 }
 


### PR DESCRIPTION
## What

Nothing major. About 20 fixes, and 15 features.

No reason to stay behind either.

Release notes: https://github.com/concourse/concourse/releases/tag/v5.7.0

## How to review

- Checkout staging