### PR TITLE
Prevent Concourse EIP destruction

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-subnets/eips.tf
+++ b/reliability-engineering/terraform/modules/concourse-subnets/eips.tf
@@ -5,6 +5,10 @@ resource "aws_eip" "concourse_egress" {
     Name       = "${var.deployment}-${var.name}"
     Deployment = "${var.deployment}"
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 output "concourse_egress_public_ips" {


### PR DESCRIPTION
People expect these IPs to be static.