### PR TITLE
Disable web page test provisioning

### DIFF
--- a/reliability-engineering/terraform/modules/web-page-test-cluster/ec2.tf
+++ b/reliability-engineering/terraform/modules/web-page-test-cluster/ec2.tf
@@ -177,6 +177,22 @@ resource "aws_lb_listener" "web_page_test_controller" {
   }
 }
 
+resource "aws_lb_listener" "web_page_test_controller_http_redirect" {
+  load_balancer_arn = "${aws_lb.web_page_test_controller.arn}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
 resource "aws_route53_record" "web_page_test" {
   name    = "${var.subdomain}.${var.domain}"
   type    = "A"
@@ -199,7 +215,7 @@ resource "null_resource" "web_page_test_controller_provisioning" {
 
   triggers = {
     locations_ini_content = "${sha1(file("${path.module}/files/ec2_locations.ini"))}"
-    instance_id = "${aws_instance.web_page_test_controller.id}"
+    instance_id           = "${aws_instance.web_page_test_controller.id}"
   }
 
   provisioner "file" {

--- a/reliability-engineering/terraform/modules/web-page-test-cluster/ec2.tf
+++ b/reliability-engineering/terraform/modules/web-page-test-cluster/ec2.tf
@@ -218,15 +218,15 @@ resource "null_resource" "web_page_test_controller_provisioning" {
     instance_id           = "${aws_instance.web_page_test_controller.id}"
   }
 
-  provisioner "file" {
-    source      = "${path.module}/files/ec2_locations.ini"
-    destination = "/tmp/ec2_locations.ini"
-  }
+  // provisioner "file" {
+  //   source      = "${path.module}/files/ec2_locations.ini"
+  //   destination = "/tmp/ec2_locations.ini"
+  // }
 
-  provisioner "remote-exec" {
-    inline = [
-      "sudo mv /tmp/ec2_locations.ini /var/www/webpagetest/www/settings/ec2_locations.ini",
-      "sudo chown www-data:www-data /var/www/webpagetest/www/settings/ec2_locations.ini",
-    ]
-  }
+  // provisioner "remote-exec" {
+  //   inline = [
+  //     "sudo mv /tmp/ec2_locations.ini /var/www/webpagetest/www/settings/ec2_locations.ini",
+  //     "sudo chown www-data:www-data /var/www/webpagetest/www/settings/ec2_locations.ini",
+  //   ]
+  // }
 }


### PR DESCRIPTION
So we can run tests again

We should look into this again in future, so we can disable the other regions

However this provisioning broke

- logging in
- running tests

for some reason