### PR TITLE
BAU: Replace HTTPS with TLS for Concourse

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/lb.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/lb.tf
@@ -21,7 +21,7 @@ resource "aws_lb_target_group" "concourse_web" {
 resource "aws_lb_listener" "concourse_web_https" {
   load_balancer_arn = "${aws_lb.concourse_web.arn}"
   port              = "443"
-  protocol          = "HTTPS"
+  protocol          = "TLS"
   ssl_policy        = "ELBSecurityPolicy-2015-05"
   certificate_arn   = "${aws_acm_certificate_validation.concourse_public_deployment.certificate_arn}"
 


### PR DESCRIPTION
I tried to execute fly command to intercept builds and got the following error message.

`error: websocket: bad handshake`

According to the issue (source: https://github.com/concourse/fly/issues/108) raised in concourse/fly GitHub repository, AWS load balancer needs to be set up with TCP or SSL listeners and not http or https so that intercept or hijack can work. This changes replaces HTTPS with TLS to resolve the bad handshake error.

Author: @adityapahuja