### PR TITLE
allow access to concourse grafana for org not team

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/grafana-container-def.json
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/grafana-container-def.json
@@ -40,8 +40,8 @@
         "value": "true"
       },
       {
-        "name": "GF_AUTH_GITHUB_TEAM_IDS",
-        "value": "${github_team_ids}"
+        "name": "GF_AUTH_GITHUB_ALLOWED_ORGANIZATIONS",
+        "value": "${github_allowed_organizations}"
       },
       {
         "name": "GF_EXPLORE_ENABLED",

--- a/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
@@ -57,11 +57,11 @@ data "template_file" "concourse_grafana_container_def" {
   template = "${file("${path.module}/files/grafana-container-def.json")}"
 
   vars {
-    deployment      = "${var.deployment}"
-    grafana_url     = "${local.grafana_url}"
-    database_host   = "${aws_db_instance.concourse_grafana_db.endpoint}"
-    aws_account_id  = "${data.aws_caller_identity.account.account_id}"
-    github_team_ids = "${join(",", var.grafana_allowed_github_team_ids)}"
+    deployment                   = "${var.deployment}"
+    grafana_url                  = "${local.grafana_url}"
+    database_host                = "${aws_db_instance.concourse_grafana_db.endpoint}"
+    aws_account_id               = "${data.aws_caller_identity.account.account_id}"
+    github_allowed_organizations = "${join(",", var.grafana_github_allowed_organizations)}"
   }
 }
 

--- a/reliability-engineering/terraform/modules/concourse-monitoring/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/variables.tf
@@ -30,7 +30,7 @@ variable "whitelisted_cidr_blocks" {
   type = "list"
 }
 
-variable "grafana_allowed_github_team_ids" {
+variable "grafana_github_allowed_organizations" {
   type = "list"
 }
 


### PR DESCRIPTION
we would like to allow much wider access to the concourse metrics
(grafana) than just the autom8 team. This updates the module so that we
can pass in an organisation instead of a team, which will allow us to
allow authentication to grafana org-wide.