### PR TITLE
[cyber/security-audit-role] bump to terraform 0.12

### DIFF
--- a/cyber-security/modules/gds_security_audit_role/gds_security_audit_role.tf
+++ b/cyber-security/modules/gds_security_audit_role/gds_security_audit_role.tf
@@ -1,19 +1,20 @@
 data "template_file" "trust" {
-  template = "${file("${path.module}/json/trust.json")}"
+  template = file("${path.module}/json/trust.json")
 
-  vars {
-    prefix            = "${var.prefix}"
-    chain_account_id  = "${var.chain_account_id}"
+  vars = {
+    prefix           = var.prefix
+    chain_account_id = var.chain_account_id
   }
 }
 
 resource "aws_iam_role" "gds_security_audit_role" {
   name = "${var.prefix}GDSSecurityAudit"
 
-  assume_role_policy = "${data.template_file.trust.rendered}"
+  assume_role_policy = data.template_file.trust.rendered
 }
 
 resource "aws_iam_role_policy_attachment" "gds_security_audit_role_policy_attachment" {
-  role       = "${aws_iam_role.gds_security_audit_role.name}"
+  role       = aws_iam_role.gds_security_audit_role.name
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }
+

--- a/cyber-security/modules/gds_security_audit_role/inline_policies.tf
+++ b/cyber-security/modules/gds_security_audit_role/inline_policies.tf
@@ -7,9 +7,9 @@ data "aws_iam_policy_document" "support_inline_policy_document" {
 }
 
 resource "aws_iam_role_policy" "support_inline_policy" {
-  name    = "${var.prefix}GDSSecurityAuditInlineSupportPolicy"
-  role    = "${aws_iam_role.gds_security_audit_role.id}"
-  policy  = "${data.aws_iam_policy_document.support_inline_policy_document.json}"
+  name   = "${var.prefix}GDSSecurityAuditInlineSupportPolicy"
+  role   = aws_iam_role.gds_security_audit_role.id
+  policy = data.aws_iam_policy_document.support_inline_policy_document.json
 }
 
 data "aws_iam_policy_document" "sts_inline_policy_document" {
@@ -21,7 +21,8 @@ data "aws_iam_policy_document" "sts_inline_policy_document" {
 }
 
 resource "aws_iam_role_policy" "sts_inline_policy" {
-  name    = "${var.prefix}GDSSecurityAuditInlineSTSPolicy"
-  role    = "${aws_iam_role.gds_security_audit_role.id}"
-  policy  = "${data.aws_iam_policy_document.sts_inline_policy_document.json}"
+  name   = "${var.prefix}GDSSecurityAuditInlineSTSPolicy"
+  role   = aws_iam_role.gds_security_audit_role.id
+  policy = data.aws_iam_policy_document.sts_inline_policy_document.json
 }
+

--- a/cyber-security/modules/gds_security_audit_role/output.tf
+++ b/cyber-security/modules/gds_security_audit_role/output.tf
@@ -1,11 +1,12 @@
 output "role_id" {
-  value = "${aws_iam_role.gds_security_audit_role.id}"
+  value = aws_iam_role.gds_security_audit_role.id
 }
 
 output "role_arn" {
-  value = "${aws_iam_role.gds_security_audit_role.arn}"
+  value = aws_iam_role.gds_security_audit_role.arn
 }
 
 output "role_name" {
-  value = "${aws_iam_role.gds_security_audit_role.name}"
+  value = aws_iam_role.gds_security_audit_role.name
 }
+

--- a/cyber-security/modules/gds_security_audit_role/versions.tf
+++ b/cyber-security/modules/gds_security_audit_role/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This upgrades the module to terraform 0.12.

Terraform 0.12 has been out for a while.  Continuing to use tf 0.11
syntax in here causes errors in consumers, such as:

```
Error: Unsupported block type

  on .terraform/modules/cyber_security_audit_role/cyber-security/modules/gds_security_audit_role/gds_security_audit_role.tf line 4, in data "template_file" "trust":
   4:   vars {

Blocks of type "vars" are not expected here. Did you mean to define argument
"vars"? If so, use the equals sign to assign it a value.
```

This commit upgrades to tf 0.12, mostly by running the handy
`terraform 0.12upgrade` command.

Consumers should pin to a commit hash so this shouldn't break existing
users.