### PR TITLE
concourse-worker-pool: Take Concourse egress IPs and put them into an SSM secret

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-worker-pool/pipeline-helpers.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/pipeline-helpers.tf
@@ -153,3 +153,15 @@ resource "aws_ssm_parameter" "concourse_worker_secrets_kms_key_id" {
     Deployment = var.deployment
   }
 }
+
+resource "aws_ssm_parameter" "concourse_worker_egress_ips" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_egress_ips"
+
+  type        = "StringList"
+  description = "Egress IPs for ${var.deployment}/${var.name}"
+  value       = var.egress_ips
+
+  tags = {
+    Deployment = var.deployment
+  }
+}

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/pipeline-helpers.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/pipeline-helpers.tf
@@ -159,7 +159,7 @@ resource "aws_ssm_parameter" "concourse_worker_egress_ips" {
 
   type        = "String"
   description = "Egress IPs for ${var.deployment}/${var.name}"
-  value       = join(',', var.egress_ips)
+  value       = join(",", var.egress_ips)
 
   tags = {
     Deployment = var.deployment

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/pipeline-helpers.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/pipeline-helpers.tf
@@ -157,9 +157,9 @@ resource "aws_ssm_parameter" "concourse_worker_secrets_kms_key_id" {
 resource "aws_ssm_parameter" "concourse_worker_egress_ips" {
   name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_egress_ips"
 
-  type        = "StringList"
+  type        = "String"
   description = "Egress IPs for ${var.deployment}/${var.name}"
-  value       = var.egress_ips
+  value       = join(',', var.egress_ips)
 
   tags = {
     Deployment = var.deployment

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/variables.tf
@@ -10,6 +10,10 @@ variable "subnet_ids" {
   type = list(string)
 }
 
+variable "egress_ips" {
+  type = list(string)
+}
+
 variable "security_group_ids" {
   type = list(string)
 }


### PR DESCRIPTION
So we can expose them in info pipelines.

See also https://github.com/alphagov/tech-ops-private/pull/329