### PR TITLE
add a pipeline to apply cd/cd-staging terraform

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -1,0 +1,150 @@
+
+resource_types:
+
+- name: terraform
+  type: registry-image
+  source:
+    repository: ljfranklin/terraform-resource
+    tag: 0.12.25
+
+resources:
+
+- name: config
+  icon: github-circle
+  type: git
+  source:
+    branch: master
+    uri: git@github.com:alphagov/tech-ops-private.git
+    private_key: ((re-autom8-ci-github-ssh-private-key))
+    paths:
+      - reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
+- name: modules
+  icon: github-circle
+  type: git
+  source:
+    branch: selfdeploy
+    uri: git@github.com:alphagov/tech-ops.git
+    private_key: ((re-autom8-ci-github-ssh-private-key))
+    paths:
+      - reliability-engineering/terraform/modules
+      - reliability-engineering/pipelines/tasks/asg-scale-max-capacity.yml
+      - reliability-engineering/pipelines/tasks/concourse-land-workers.yml
+      - reliability-engineering/pipelines/tasks/concourse-provider-config.yml
+      - reliability-engineering/pipelines/concourse-deployer.yml
+- name: deployment
+  icon: terraform
+  type: terraform
+  source:
+    env_name: default
+    backend_type: s3
+    private_key: ((re-autom8-ci-github-ssh-private-key))
+    backend_config:
+      bucket: gds-tech-ops-tfstate
+      region: eu-west-2
+      key: ((deployment_name)).tfstate
+
+jobs:
+
+- name: update
+  serial: true
+  serial_groups: [deploy]
+  plan:
+  - in_parallel:
+    - get: config
+      trigger: true
+    - get: modules
+      trigger: true
+    - get: deployment
+  - set_pipeline: deploy
+    file: modules/reliability-engineering/pipelines/concourse-deployer.yml
+    vars:
+      deployment_name: ((deployment_name))
+
+- name: deploy
+  serial: true
+  serial_groups: [deploy]
+  plan:
+  - in_parallel:
+    - get: config
+      passed: [update]
+      trigger: true
+    - get: modules
+      passed: [update]
+      trigger: true
+    - get: deployment
+      passed: [update]
+  - task: configure-providers
+    file: modules/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
+    params:
+      DEPLOYMENT_NAME: ((deployment_name))
+  - put: deployment
+    params:
+      terraform_source: config/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
+      override_files:
+      - concourse-provider-config/provider_concourse_override.tf.json
+
+- name: scale-out
+  serial: true
+  serial_groups: [deploy]
+  plan:
+  - in_parallel:
+    - get: config
+      passed: [deploy]
+      trigger: true
+    - get: modules
+      passed: [deploy]
+      trigger: true
+    - get: deployment
+      passed: [deploy]
+  - task: configure-providers
+    file: modules/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
+    params:
+      DEPLOYMENT_NAME: ((deployment_name))
+  - do:
+    - task: get-current-workers
+      file: modules/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
+      params:
+        DEPLOYMENT_NAME: ((deployment_name))
+    - in_parallel:
+      - task: scale-out-web-node-asg
+        file: modules/reliability-engineering/pipelines/tasks/asg-scale-max-capacity.yml
+        params:
+          ASG_PREFIX: ((deployment_name))-concourse-web
+      - task: scale-out-main-team-workers-asg
+        file: modules/reliability-engineering/pipelines/tasks/asg-scale-max-capacity.yml
+        params:
+          ASG_PREFIX: ((deployment_name))-main-concourse-worker
+    - task: land-old-workers
+      file: modules/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
+      params:
+        DEPLOYMENT_NAME: ((deployment_name))
+    on_failure:
+      put: deployment # try to scale back in on failure to stay in sync
+      attempts: 10
+      params:
+        terraform_source: config/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
+        override_files:
+        - concourse-provider-config/provider_concourse_override.tf.json
+
+- name: scale-in
+  serial: true
+  serial_groups: [deploy]
+  plan:
+  - in_parallel:
+    - get: config
+      passed: [scale-out]
+      trigger: true
+    - get: modules
+      passed: [scale-out]
+      trigger: true
+    - get: deployment
+      passed: [scale-out]
+  - task: configure-providers
+    file: modules/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
+    params:
+      DEPLOYMENT_NAME: ((deployment_name))
+  - put: deployment
+    params:
+      terraform_source: config/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
+      override_files:
+      - concourse-provider-config/provider_concourse_override.tf.json

--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -13,7 +13,7 @@ resources:
   icon: github-circle
   type: git
   source:
-    branch: module-paths
+    branch: ((deployment_branch))
     uri: git@github.com:alphagov/tech-ops-private.git
     private_key: ((re-autom8-ci-github-ssh-private-key))
     paths:
@@ -22,7 +22,7 @@ resources:
   icon: github-circle
   type: git
   source:
-    branch: selfdeploy
+    branch: ((deployment_branch))
     uri: git@github.com:alphagov/tech-ops.git
     private_key: ((re-autom8-ci-github-ssh-private-key))
     paths:
@@ -59,6 +59,7 @@ jobs:
     file: tech-ops/reliability-engineering/pipelines/concourse-deployer.yml
     vars:
       deployment_name: ((deployment_name))
+      deployment_branch: ((deployment_branch))
 
 - name: deploy
   serial: true

--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -9,16 +9,16 @@ resource_types:
 
 resources:
 
-- name: config
+- name: tech-ops-private
   icon: github-circle
   type: git
   source:
-    branch: master
+    branch: module-paths
     uri: git@github.com:alphagov/tech-ops-private.git
     private_key: ((re-autom8-ci-github-ssh-private-key))
     paths:
       - reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
-- name: modules
+- name: tech-ops
   icon: github-circle
   type: git
   source:
@@ -31,7 +31,7 @@ resources:
       - reliability-engineering/pipelines/tasks/concourse-land-workers.yml
       - reliability-engineering/pipelines/tasks/concourse-provider-config.yml
       - reliability-engineering/pipelines/concourse-deployer.yml
-- name: deployment
+- name: infra
   icon: terraform
   type: terraform
   source:
@@ -50,13 +50,13 @@ jobs:
   serial_groups: [deploy]
   plan:
   - in_parallel:
-    - get: config
+    - get: tech-ops-private
       trigger: true
-    - get: modules
+    - get: tech-ops
       trigger: true
-    - get: deployment
+    - get: infra
   - set_pipeline: deploy
-    file: modules/reliability-engineering/pipelines/concourse-deployer.yml
+    file: tech-ops/reliability-engineering/pipelines/concourse-deployer.yml
     vars:
       deployment_name: ((deployment_name))
 
@@ -65,21 +65,21 @@ jobs:
   serial_groups: [deploy]
   plan:
   - in_parallel:
-    - get: config
+    - get: tech-ops-private
       passed: [update]
       trigger: true
-    - get: modules
+    - get: tech-ops
       passed: [update]
       trigger: true
-    - get: deployment
+    - get: infra
       passed: [update]
   - task: configure-providers
-    file: modules/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
+    file: tech-ops/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
     params:
       DEPLOYMENT_NAME: ((deployment_name))
-  - put: deployment
+  - put: infra
     params:
-      terraform_source: config/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
+      terraform_source: tech-ops-private/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
       override_files:
       - concourse-provider-config/provider_concourse_override.tf.json
 
@@ -88,41 +88,41 @@ jobs:
   serial_groups: [deploy]
   plan:
   - in_parallel:
-    - get: config
+    - get: tech-ops-private
       passed: [deploy]
       trigger: true
-    - get: modules
+    - get: tech-ops
       passed: [deploy]
       trigger: true
-    - get: deployment
+    - get: infra
       passed: [deploy]
   - task: configure-providers
-    file: modules/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
+    file: tech-ops/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
     params:
       DEPLOYMENT_NAME: ((deployment_name))
   - do:
     - task: get-current-workers
-      file: modules/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
+      file: tech-ops/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
       params:
         DEPLOYMENT_NAME: ((deployment_name))
     - in_parallel:
       - task: scale-out-web-node-asg
-        file: modules/reliability-engineering/pipelines/tasks/asg-scale-max-capacity.yml
+        file: tech-ops/reliability-engineering/pipelines/tasks/asg-scale-max-capacity.yml
         params:
           ASG_PREFIX: ((deployment_name))-concourse-web
       - task: scale-out-main-team-workers-asg
-        file: modules/reliability-engineering/pipelines/tasks/asg-scale-max-capacity.yml
+        file: tech-ops/reliability-engineering/pipelines/tasks/asg-scale-max-capacity.yml
         params:
           ASG_PREFIX: ((deployment_name))-main-concourse-worker
     - task: land-old-workers
-      file: modules/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
+      file: tech-ops/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
       params:
         DEPLOYMENT_NAME: ((deployment_name))
     on_failure:
-      put: deployment # try to scale back in on failure to stay in sync
+      put: infra # try to scale back in on failure to stay in sync
       attempts: 10
       params:
-        terraform_source: config/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
+        terraform_source: tech-ops-private/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
         override_files:
         - concourse-provider-config/provider_concourse_override.tf.json
 
@@ -131,20 +131,20 @@ jobs:
   serial_groups: [deploy]
   plan:
   - in_parallel:
-    - get: config
+    - get: tech-ops-private
       passed: [scale-out]
       trigger: true
-    - get: modules
+    - get: tech-ops
       passed: [scale-out]
       trigger: true
-    - get: deployment
+    - get: infra
       passed: [scale-out]
   - task: configure-providers
-    file: modules/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
+    file: tech-ops/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
     params:
       DEPLOYMENT_NAME: ((deployment_name))
-  - put: deployment
+  - put: infra
     params:
-      terraform_source: config/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
+      terraform_source: tech-ops-private/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
       override_files:
       - concourse-provider-config/provider_concourse_override.tf.json

--- a/reliability-engineering/pipelines/tasks/asg-scale-max-capacity.yml
+++ b/reliability-engineering/pipelines/tasks/asg-scale-max-capacity.yml
@@ -1,0 +1,61 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: govsvc/task-toolbox
+    tag: latest
+params:
+  AWS_DEFAULT_REGION: eu-west-2
+  ASG_PREFIX:
+run:
+  path: /bin/bash
+  args:
+  - -euo
+  - pipefail
+  - -c
+  - |
+    function asg_fetch_info() {
+      aws autoscaling describe-auto-scaling-groups \
+        | jq "\
+          .AutoScalingGroups[] \
+          | select(.AutoScalingGroupName \
+            | startswith(\"${ASG_PREFIX}\")\
+          )\
+        " > asg.json
+    }
+    function asg_instance_count() {
+      jq -r '.Instances | length' <asg.json
+    }
+    function asg_max_size() {
+      jq -r '.MaxSize' <asg.json
+    }
+    function asg_min_size() {
+      jq -r '.MinSize' <asg.json
+    }
+    function asg_name() {
+      jq -r '.AutoScalingGroupName' <asg.json
+    }
+    function asg_instance_count_inservice() {
+      jq -r '[.Instances[].LifecycleState | select(. == "InService")] | length' <asg.json
+    }
+    function asg_set_desired() {
+      desired="$1"
+      aws autoscaling set-desired-capacity \
+        --auto-scaling-group-name "$(asg_name)" \
+        --desired-capacity "${desired}"
+      while [[ "$(asg_instance_count)" != "${desired}" ]]; do
+        echo "waiting for instance count ($(asg_instance_count)) to match desired count ($desired)..."
+        sleep 5
+        asg_fetch_info
+      done
+      while [[ "$(asg_instance_count_inservice)" != "${desired}" ]]; do
+        echo "waiting for instance count in service ($(asg_instance_count_inservice)) to match desired count ($desired)..."
+        sleep 5
+        asg_fetch_info
+      done
+    }
+    echo "fetching asg state..."
+    asg_fetch_info
+    echo "trigger scale-out of $(asg_name) to $(asg_max_size) instances..."
+    asg_set_desired $(asg_max_size)
+    echo "OK"

--- a/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
+++ b/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
@@ -5,7 +5,7 @@ image_resource:
     repository: concourse/concourse-pipeline-resource
     tag: 2.2.0
 params:
-  DEPLOYMENT_NAME: cd-staging
+  DEPLOYMENT_NAME:
   FLY_USERNAME: main
   FLY_TEAM: main
 inputs:

--- a/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
+++ b/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
@@ -1,0 +1,34 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: concourse/concourse-pipeline-resource
+    tag: 2.2.0
+params:
+  DEPLOYMENT_NAME: cd-staging
+  FLY_USERNAME: main
+  FLY_TEAM: main
+inputs:
+- name: concourse-provider-config
+outputs:
+- name: workers
+run:
+  path: sh
+  args:
+  - -euo
+  - pipefail
+  - -c
+  - |
+    echo "configuring fly..."
+    export PATH="$PATH:/opt/resource"
+    FLY_PASSWORD=$(cat concourse-provider-config/main_team_password)
+    fly -t concourse login \
+      -c "https://${DEPLOYMENT_NAME}.gds-reliability.engineering" \
+      -u "${FLY_USERNAME}" \
+      -p "${FLY_PASSWORD}" \
+      -n "${FLY_TEAM}"
+    fly -t concourse sync
+    echo "fetching concourse worker names for ${FLY_TEAM}..."
+    mkdir -p workers
+    fly -t concourse workers | grep "${FLY_TEAM}" | awk '{print $1}' > workers/names
+    echo "OK!"

--- a/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
+++ b/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
@@ -5,7 +5,7 @@ image_resource:
     repository: concourse/concourse-pipeline-resource
     tag: 2.2.0
 params:
-  DEPLOYMENT_NAME: cd-staging
+  DEPLOYMENT_NAME:
   FLY_USERNAME: main
   FLY_TEAM: main
 inputs:

--- a/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
+++ b/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
@@ -1,0 +1,49 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: concourse/concourse-pipeline-resource
+    tag: 2.2.0
+params:
+  DEPLOYMENT_NAME: cd-staging
+  FLY_USERNAME: main
+  FLY_TEAM: main
+inputs:
+- name: concourse-provider-config
+- name: workers
+run:
+  path: sh
+  args:
+  - -euo
+  - pipefail
+  - -c
+  - |
+    echo "configuring fly..."
+    export PATH="$PATH:/opt/resource"
+    FLY_PASSWORD=$(cat concourse-provider-config/main_team_password)
+    fly -t concourse login \
+      -c "https://${DEPLOYMENT_NAME}.gds-reliability.engineering" \
+      -u "${FLY_USERNAME}" \
+      -p "${FLY_PASSWORD}" \
+      -n "${FLY_TEAM}"
+    fly -t concourse sync
+    echo "waiting for the new workers to appear..."
+    function get_current_worker_count() {
+      fly -t concourse workers | grep "${FLY_TEAM}" | wc -l
+    }
+    function get_old_worker_count() {
+      wc -l <workers/names
+    }
+    while [ "$(get_current_worker_count)" = "$(get_old_worker_count)" ]; do
+      echo "...still only $(get_old_worker_count) workers"
+      sleep 3
+    done
+    echo "OK!"
+    echo "landing old workers..."
+    for worker in $(cat workers/names); do
+      echo "--> ${worker} coming in for landing!"
+      fly -t concourse land-worker --worker "${worker}"
+    done
+    echo "wait for landing..."
+    sleep 15 # TODO: we can do better!
+    echo "OK!"

--- a/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
+++ b/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
@@ -1,0 +1,37 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: govsvc/task-toolbox
+    tag: latest
+inputs:
+- name: deployment
+outputs:
+- name: concourse-provider-config
+params:
+  DEPLOYMENT_NAME:
+run:
+  path: /bin/bash
+  args:
+  - -euo
+  - pipefail
+  - -c
+  - |
+    echo "genertaing concourse provider config..."
+    mkdir -p concourse-provider-config
+    cat <<EOF > concourse-provider-config/provider_concourse_override.tf.json
+    {
+      "provider": {
+        "concourse": {
+          "target": "",
+          "url": "https://${DEPLOYMENT_NAME}.gds-reliability.engineering",
+          "team": "main",
+          "username": "main",
+          "password": "$(jq -r .main_team_password <deployment/metadata)"
+        }
+      }
+    }
+    EOF
+    echo "writing main team password to file..."
+    jq -r .main_team_password <deployment/metadata > concourse-provider-config/main_team_password
+    echo "OK!"

--- a/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
+++ b/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
@@ -5,7 +5,7 @@ image_resource:
     repository: govsvc/task-toolbox
     tag: latest
 inputs:
-- name: deployment
+- name: infra # terraform metadata
 outputs:
 - name: concourse-provider-config
 params:
@@ -27,11 +27,11 @@ run:
           "url": "https://${DEPLOYMENT_NAME}.gds-reliability.engineering",
           "team": "main",
           "username": "main",
-          "password": "$(jq -r .main_team_password <deployment/metadata)"
+          "password": "$(jq -r .main_team_password <infra/metadata)"
         }
       }
     }
     EOF
     echo "writing main team password to file..."
-    jq -r .main_team_password <deployment/metadata > concourse-provider-config/main_team_password
+    jq -r .main_team_password <infra/metadata > concourse-provider-config/main_team_password
     echo "OK!"

--- a/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
+++ b/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
@@ -17,7 +17,7 @@ run:
   - pipefail
   - -c
   - |
-    echo "genertaing concourse provider config..."
+    echo "generating concourse provider config..."
     mkdir -p concourse-provider-config
     cat <<EOF > concourse-provider-config/provider_concourse_override.tf.json
     {

--- a/reliability-engineering/terraform/modules/concourse-web/autoscaling-group.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/autoscaling-group.tf
@@ -7,6 +7,11 @@ resource "aws_autoscaling_group" "concourse_web" {
   target_group_arns   = [aws_lb_target_group.concourse_web.arn]
   load_balancers      = [aws_elb.concourse_web.name]
 
+  termination_policies = [
+    "OldestLaunchConfiguration",
+    "OldestInstance",
+  ]
+
   launch_template {
     id      = aws_launch_template.concourse_web.id
     version = "$Latest"

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
@@ -5,6 +5,11 @@ resource "aws_autoscaling_group" "concourse_worker" {
   desired_capacity    = var.desired_capacity
   vpc_zone_identifier = var.subnet_ids
 
+  termination_policies = [
+    "OldestLaunchConfiguration",
+    "OldestInstance",
+  ]
+
   launch_template {
     id      = aws_launch_template.concourse_worker.id
     version = "$Latest"


### PR DESCRIPTION
## What

pipeline for applying cd/cd-staging terraform that:

* selfupdates the pipeline
* grabs main team password from terraform state
* applies latest terraform
* scales out web-nodes asg to max-size
* scales out worker nodes asg to max-size
* lands the old workers
* scales in web-nodes to desired size
* scales in worker-nodes to desired size

The pipeline requires `deployment_name` (ie "cd" or "cd-staging") and `deployment_branch` (ie "master") ... this lets us use the same pipeline accross both deployments and enables a prod deployment from a dedicated tag/branch.

The asgs are updated to use a "oldest first" termination policy so that changes to the scaling result in a rolling of the nodes.

## Why

So concourse config can be continuously deployed

## Where

Here: https://cd-staging.gds-reliability.engineering/teams/main/pipelines/deploy (please don't unpause til merged to master!)

## Required

* [x] https://github.com/alphagov/tech-ops-private/pull/348