### PR TITLE
add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,14 @@
+# default owners
+* @alphagov/re-common-cloud @alphagov/re-autom8 @alphagov/reliability-engineering
+
+# shared concourse owners
+# parts of the reliability-engineering terraform control deployment of the
+# shared concourse infrastructure and as such require approval from a smaller
+# subset of maintainers, in the future we may implement an alternative method
+# enforcing this policy that relaxes this requirement
+reliability-engineering/pipelines/concourse-deployer.yml @alphagov/re-common-cloud
+reliability-engineering/pipelines/tasks/* @alphagov/re-common-cloud
+reliability-engineering/terraform/modules/concourse-* @alphagov/re-common-cloud
+
+# cyber security owners
+cyber-security/* @alphagov/reliability-engineering @alphagov/team-cybersecurity

--- a/cyber-security/components/csls-splunk-broker/CODEOWNERS
+++ b/cyber-security/components/csls-splunk-broker/CODEOWNERS
@@ -1,3 +1,0 @@
-# This project was a cross-team effort requiring knowledge of GOV.UK PaaS and
-# the Cyber kinesis logging pipeline for splunk ingestion and is now owned by both teams.
-* @alphagov/reliability-engineering @alphagov/team-cybersecurity


### PR DESCRIPTION
## what

Add CODEOWNERS for some relevent sections of this repo

## Why

So that we can enable branch protection rules to limit the set of people who can approve changes to the shared concourse deployment