### PR TITLE
cd-pipeline: verify the tag itself not the HEAD commit

### DIFF
--- a/reliability-engineering/pipelines/tasks/verify-tag.yml
+++ b/reliability-engineering/pipelines/tasks/verify-tag.yml
@@ -27,9 +27,11 @@ run:
       echo "${GPG_VERIFICATION_KEY}" > key
       gpg --import key
       export GPG_TTY=$(tty)
+      export TERM=xterm
       echo "trusted keys..."
       gpg --list-keys
-      echo "verifying commit signed by a trusted key..."
+      echo "finding tag..."
       cd repository
-      git tag --points-at HEAD
-      git verify-commit HEAD
+      TAG=$(cat .git/ref)
+      echo "verifying $TAG signed by a trusted key..."
+      git tag -v "${TAG}"


### PR DESCRIPTION
tag verification was failing because there is a seperate HEAD for the
signed tag that points to the checked out HEAD.

fix by using "git tag -v" not "git verify-commit"