### PR TITLE
Try whitelisting access from Concourse to Grafana via the NAT Gateway…

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/security-groups.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/security-groups.tf
@@ -38,17 +38,7 @@ resource "aws_security_group_rule" "concourse_monitoring_lb_ingress_from_outside
   to_port   = 443
 
   security_group_id = aws_security_group.concourse_monitoring_lb.id
-  cidr_blocks       = var.whitelisted_cidr_blocks
-}
-
-resource "aws_security_group_rule" "concourse_monitoring_lb_ingress_from_concourse_main_443" {
-  type              = "ingress"
-  protocol          = "tcp"
-  from_port         = 443
-  to_port           = 443
-
-  security_group_id        = aws_security_group.concourse_monitoring_lb.id
-  source_security_group_id = var.main_worker_security_group_id
+  cidr_blocks       = concat(var.whitelisted_cidr_blocks, var.main_nat_gateway_egress_ips)
 }
 
 resource "aws_security_group_rule" "concourse_monitoring_lb_ingress_from_outside_80" {

--- a/reliability-engineering/terraform/modules/concourse-monitoring/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/variables.tf
@@ -14,7 +14,7 @@ variable "public_subnet_ids" {
   type = list(string)
 }
 
-variable "main_worker_security_group_id" {
+variable "main_nat_gateway_egress_ips" {
   type = string
 }
 


### PR DESCRIPTION
… egress IP

After thinking about it for a bit, I realised the existing rule probably wasn't
working because the concourse worker has to egress to the internet via the NAT
Gateway and then go into the monitoring ELB, which I imagine means its security
group has no effect used as a source to ingress to the ELB.