### PR TITLE
automate deploying concourse from upstream release

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -64,6 +64,11 @@ resources:
   icon: layers
   source:
     repository: ((readonly_private_ecr_repo_url))
+- name: concourse-release
+  type: github-release
+  source:
+    owner: concourse
+    repository: concourse
 
 jobs:
 
@@ -104,6 +109,11 @@ jobs:
       trigger: true
     - get: infra
       passed: [update]
+    - get: concourse-release
+      trigger: true
+      params:
+        globs:
+        - concourse-*-linux-amd64.tgz.sha1
   - task: configure-providers
     file: tech-ops/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
     params:
@@ -113,6 +123,8 @@ jobs:
       terraform_source: tech-ops-private/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
       override_files:
       - concourse-provider-config/provider_concourse_override.tf.json
+      var_files:
+      - concourse-provider-config/version.tfvars
   - set_pipeline: roll-instances
     file: tech-ops-private/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))/roll-instances.yml
   - set_pipeline: deploy-info-pipelines
@@ -133,6 +145,11 @@ jobs:
       trigger: true
     - get: infra
       passed: [deploy]
+    - get: concourse-release
+      passed: [deploy]
+      params:
+        globs:
+        - concourse-*-linux-amd64.tgz.sha1
   - task: configure-providers
     file: tech-ops/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
     params:
@@ -162,6 +179,8 @@ jobs:
         terraform_source: tech-ops-private/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
         override_files:
         - concourse-provider-config/provider_concourse_override.tf.json
+        var_files:
+        - concourse-provider-config/version.tfvars
 
 - name: scale-in
   serial: true
@@ -176,6 +195,11 @@ jobs:
       trigger: true
     - get: infra
       passed: [scale-out]
+    - get: concourse-release
+      passed: [scale-out]
+      params:
+        globs:
+        - concourse-*-linux-amd64.tgz.sha1
   - task: configure-providers
     file: tech-ops/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
     params:
@@ -186,6 +210,8 @@ jobs:
       terraform_source: tech-ops-private/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
       override_files:
       - concourse-provider-config/provider_concourse_override.tf.json
+      var_files:
+      - concourse-provider-config/version.tfvars
 
 - name: test
   serial: true

--- a/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
+++ b/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
@@ -6,6 +6,7 @@ image_resource:
     tag: latest
 inputs:
 - name: infra # terraform metadata
+- name: concourse-release
 outputs:
 - name: concourse-provider-config
 params:
@@ -32,6 +33,12 @@ run:
       }
     }
     EOF
+    echo "generating version config..."
+    cat <<-EOF > concourse-provider-config/version.tfvars
+      concourse_version = "$(cat concourse-release/version)"
+      concourse_sha1 = "$(cat concourse-release/concourse-*-linux-amd64.tgz.sha1)"
+    EOF
+    cat concourse-provider-config/version.tfvars
     echo "writing main team password to file..."
     jq -r .main_team_password <infra/metadata > concourse-provider-config/main_team_password
     echo "OK!"

--- a/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
@@ -18,8 +18,8 @@ data "template_file" "concourse_web_cloud_init" {
     main_team_github_team               = var.main_team_github_team
     concourse_external_url              = aws_route53_record.concourse_public_deployment.fqdn
     concourse_db_url                    = aws_route53_record.concourse_private_db.fqdn
-    concourse_version                   = "6.0.0"
-    concourse_sha1                      = "b8696c55bea47363580e81e3710814a9cdea26ef  concourse-6.0.0-linux-amd64.tgz"
+    concourse_version                   = var.concourse_version
+    concourse_sha1                      = var.concourse_sha1
     concourse_web_bucket                = aws_s3_bucket.concourse_web.bucket
     worker_keys_s3_object_key           = aws_s3_bucket_object.concourse_web_team_authorized_worker_keys.id
     concourse_web_syslog_log_group_name = local.concourse_web_syslog_log_group_name

--- a/reliability-engineering/terraform/modules/concourse-web/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/variables.tf
@@ -94,6 +94,14 @@ variable "db_storage_gb" {
   default = 100
 }
 
+variable "concourse_version" {
+  type = string
+}
+
+variable "concourse_sha1" {
+  type = string
+}
+
 data "aws_caller_identity" "account" {}
 
 locals {

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/launch-template.tf
@@ -17,8 +17,8 @@ data "template_file" "concourse_worker_cloud_init" {
     deployment        = var.deployment
     worker_team_name  = var.name
     concourse_host    = local.concourse_url
-    concourse_version = "6.0.0"
-    concourse_sha1    = "b8696c55bea47363580e81e3710814a9cdea26ef  concourse-6.0.0-linux-amd64.tgz"
+    concourse_version = var.concourse_version
+    concourse_sha1    = var.concourse_sha1
   }
 }
 

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/variables.tf
@@ -59,4 +59,12 @@ variable "additional_concourse_worker_iam_policies" {
   default = []
 }
 
+variable "concourse_version" {
+  type = string
+}
+
+variable "concourse_sha1" {
+  type = string
+}
+
 data "aws_caller_identity" "account" {}


### PR DESCRIPTION
## What

by monitoring the github releases in the pipeline, and automatically
deploying straight to staging we can automate this process a fair bit.

We can use the concourse UI to "pin" the resource to a known good
version in the production deployment and only move it on when we are
happy that it was ok in staging.

## Why

our current process for upgrading concourse is bumping version numbers
and hash in the terraform module, this isn't exactly difficult work but
it is toil and we are regually a couple of minor versions behind.

## Future

If we are feeling brave, we could make releases that has passed staging go straight out to prod by changing prod pipeline to read from a packaged release created by staging ... but for now manually pressing the pin as a simple gate is probably ok

## Related

https://github.com/alphagov/tech-ops-private/pull/366