### PR TITLE
update pipeline to pull fly from latest

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -69,6 +69,11 @@ resources:
   source:
     owner: concourse
     repository: concourse
+- name: fly
+  type: registry-image
+  source:
+    repository: concourse/concourse-pipeline-resource
+    tag: latest
 
 jobs:
 
@@ -150,15 +155,17 @@ jobs:
       params:
         globs:
         - concourse-*-linux-amd64.tgz.sha1
+    - get: fly
   - task: configure-providers
     file: tech-ops/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
     params:
       DEPLOYMENT_NAME: ((deployment_name))
+  - task: get-current-workers
+    file: tech-ops/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
+    image: fly
+    params:
+      DEPLOYMENT_NAME: ((deployment_name))
   - do:
-    - task: get-current-workers
-      file: tech-ops/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
-      params:
-        DEPLOYMENT_NAME: ((deployment_name))
     - in_parallel:
       - task: scale-out-web-node-asg
         file: tech-ops/reliability-engineering/pipelines/tasks/asg-scale-max-capacity.yml
@@ -170,6 +177,7 @@ jobs:
           ASG_PREFIX: ((deployment_name))-main-concourse-worker
     - task: land-old-workers
       file: tech-ops/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
+      image: fly
       params:
         DEPLOYMENT_NAME: ((deployment_name))
     on_failure:

--- a/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
+++ b/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
@@ -3,7 +3,7 @@ image_resource:
   type: registry-image
   source:
     repository: concourse/concourse-pipeline-resource
-    tag: 2.2.0
+    tag: 6
 params:
   DEPLOYMENT_NAME:
   FLY_USERNAME: main

--- a/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
+++ b/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
@@ -3,7 +3,7 @@ image_resource:
   type: registry-image
   source:
     repository: concourse/concourse-pipeline-resource
-    tag: 2.2.0
+    tag: 6
 params:
   DEPLOYMENT_NAME:
   FLY_USERNAME: main


### PR DESCRIPTION
fly sync fails since auth changes in 6.2.

change pipeline to fetch latest fly from the pipeline-resource image
before attempting sync making the upgrade jump smaller.

also moves the get-workers task outside of the do/on_failure block as
it's failure does not require rollback.