### PR TITLE
ensure apt-get is non-interactive in cloudinit

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -145,7 +145,7 @@ systemctl daemon-reload
 systemctl enable concourse-web
 systemctl start  concourse-web
 
-apt-get install prometheus-node-exporter
+apt-get install --yes prometheus-node-exporter
 systemctl enable prometheus-node-exporter
 systemctl start prometheus-node-exporter
 

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
@@ -71,6 +71,6 @@ systemctl start  concourse-worker
 # see concourse/concourse #1667 and #2482
 iptables -P FORWARD ACCEPT
 
-apt-get install prometheus-node-exporter
+apt-get install --yes prometheus-node-exporter
 systemctl enable prometheus-node-exporter
 systemctl start prometheus-node-exporter


### PR DESCRIPTION
missing --yes during apt-get was causing cloud-init failure in ubuntu focal