### PR TITLE
[concourse-worker] Allow workers to be launched as spot instances

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
@@ -17,8 +17,11 @@ resource "aws_autoscaling_group" "concourse_worker" {
         version            = "$Latest"
       }
 
-      override {
-        instance_type = var.instance_type
+      dynamic "override" {
+        for_each = var.spot_instance_types
+        content {
+          instance_type = override.value
+        }
       }
     }
 

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
@@ -18,7 +18,7 @@ resource "aws_autoscaling_group" "concourse_worker" {
       }
 
       dynamic "override" {
-        for_each = var.spot_instance_types
+        for_each = coalescelist(var.spot_instance_types, [var.instance_type])
         content {
           instance_type = override.value
         }

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
@@ -26,7 +26,7 @@ resource "aws_autoscaling_group" "concourse_worker" {
     }
 
     instances_distribution {
-      on_demand_percentage_above_base_capacity = 100
+      on_demand_percentage_above_base_capacity = var.on_demand_percentage
     }
   }
 

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
@@ -10,9 +10,21 @@ resource "aws_autoscaling_group" "concourse_worker" {
     "OldestInstance",
   ]
 
-  launch_template {
-    id      = aws_launch_template.concourse_worker.id
-    version = "$Latest"
+  mixed_instances_policy {
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.concourse_worker.id
+        version            = "$Latest"
+      }
+
+      override {
+        instance_type = var.instance_type
+      }
+    }
+
+    instances_distribution {
+      on_demand_percentage_above_base_capacity = 100
+    }
   }
 
   tag {

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
@@ -100,7 +100,7 @@ Description=Check EC2 metadata for spot interruption notices
 ExecStart=/usr/local/bin/check-spot-interruption
 Type=simple
 RestartSec=3s
-Restart=always
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
@@ -73,7 +73,7 @@ TOKEN=`curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-me
 
 while sleep 5; do
 
-    HTTP_CODE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s -w %{http_code} -o /dev/null http://169.254.169.254/latest/meta-data/spot/instance-action)
+    HTTP_CODE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s -w %%{http_code} -o /dev/null http://169.254.169.254/latest/meta-data/spot/instance-action)
 
     if [[ "$HTTP_CODE" -eq 401 ]] ; then
         echo 'Refreshing Authentication Token'

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/variables.tf
@@ -46,8 +46,19 @@ variable "desired_capacity" {
   default = 1
 }
 
+variable "on_demand_percentage" {
+  default     = 100
+  description = "Percentage of instances to be launched as on-demand (ie not spot)"
+}
+
 variable "instance_type" {
   default = "t3.small"
+}
+
+variable "spot_instance_types" {
+  type        = list(string)
+  default     = []
+  description = "Instance types available for use as spot instances"
 }
 
 variable "volume_size" {


### PR DESCRIPTION
This adds two parameters to concourse-worker-pool: `on_demand_percentage`
(default 100); setting it to less than 100 will launch the remaining portion as spot instances;
and `spot_instance_types`, which is a list of allowable spot instance types.

Note that by default, all instances will be on-demand, just as they are now.

This also adds a new service which polls instance metadata every 5 seconds
for [spot interruption notices][1].  If an interruption notice is
found, it sends a SIGUSR2 to concourse-worker, which [retires the worker][2].

Also, use `systemctl enable --now` to start services to cut a few
lines from the script.

[1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html
[2]: https://concourse-ci.org/concourse-worker.html#gracefully-removing-a-worker