### PR TITLE
concourse: add pool codecommit repo per team

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -297,6 +297,19 @@ jobs:
     params:
       release: a-test-lock-config
 
+- name: tag-release
+  serial: true
+  serial_groups: [deploy]
+  plan:
+  - in_parallel:
+    - get: tech-ops
+      attempts: 50
+      passed: [test]
+      trigger: true
+    - get: version
+      attempts: 50
+      params: {bump: minor}
+
   # this promotes the repo for use in other deployments (eg cd-staging -> cd)
   - task: tag-tech-ops
     file: tech-ops/reliability-engineering/pipelines/tasks/sign-tag.yml

--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -22,7 +22,7 @@ resource_types:
 resources:
 
 - name: tech-ops-private
-  icon: github-circle
+  icon: github
   type: git
   source:
     branch: ((deployment_branch))
@@ -31,7 +31,7 @@ resources:
     paths:
       - reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
 - name: tech-ops
-  icon: github-circle
+  icon: github
   type: git
   source:
     branch: ((deployment_branch))

--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -11,6 +11,13 @@ resource_types:
   source:
     repository: governmentpaas/semver-resource
     tag: latest
+- name: pool
+  type: registry-image
+  source:
+    # pool is included by default but the bundled resource is broke
+    # https://github.com/concourse/pool-resource/pull/56
+    repository: concourse/pool-resource
+    tag: 1.1.3
 
 resources:
 
@@ -64,6 +71,27 @@ resources:
   icon: layers
   source:
     repository: ((readonly_private_ecr_repo_url))
+- name: pool-repo
+  type: git
+  icon: github
+  source:
+    branch: pool
+    uri: ((readonly_codecommit_pool_uri))
+    private_key: ((readonly_codecommit_private_key))
+- name: pool
+  type: pool
+  icon: pool
+  source:
+    branch: pool
+    uri: ((readonly_codecommit_pool_uri))
+    private_key: ((readonly_codecommit_private_key))
+    pool: my-pool
+- name: a-test-lock-config
+  type: mock
+  source:
+    create_files:
+      name: a-test-lock
+      metadata: ''
 - name: concourse-release
   type: github-release
   source:
@@ -237,12 +265,39 @@ jobs:
     - get: version
       attempts: 50
       params: {bump: minor}
-  - put: ecr # this is a simple check to ensure push to ecr works
+
+  # this is a simple check to ensure push to ecr works
+  - put: ecr
     params:
       build: version
       dockerfile: tech-ops/reliability-engineering/dockerfiles/test.Dockerfile
       tag: version/version
       tag_prefix: ((deployment_name))-
+
+  # the following tasks exercise the codecommit repo provided for pool-resource
+  - task: init-pool
+    file: tech-ops/reliability-engineering/pipelines/tasks/test-init-pool.yml
+    output_mapping:
+      repo: pool
+  - put: pool-repo
+    params:
+      repository: pool
+      force: true
+  - get: a-test-lock-config  # defines a lock
+  - put: add-lock  # adds the lock to the pool
+    resource: pool
+    params:
+      add: a-test-lock-config
+  - put: acquire-lock  # get the lock
+    resource: pool
+    params:
+      acquire: true
+  - put: release-lock  # releases the lock
+    resource: pool
+    params:
+      release: a-test-lock-config
+
+  # this promotes the repo for use in other deployments (eg cd-staging -> cd)
   - task: tag-tech-ops
     file: tech-ops/reliability-engineering/pipelines/tasks/sign-tag.yml
     input_mapping:

--- a/reliability-engineering/pipelines/tasks/test-init-pool.yml
+++ b/reliability-engineering/pipelines/tasks/test-init-pool.yml
@@ -1,0 +1,26 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: governmentpaas/git-ssh
+    tag: latest
+outputs:
+- name: repo
+run:
+  dir: repo
+  path: sh
+  args:
+  - -euo
+  - pipefail
+  - -c
+  - |
+    git init .
+
+    for pool in my-pool; do
+      mkdir -p "$pool/claimed"
+      mkdir -p "$pool/unclaimed"
+      touch "$pool/claimed/.keep"
+      touch "$pool/unclaimed/.keep"
+      git add "$pool"
+      git commit -m "setup $pool"
+    done

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/codecommit.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/codecommit.tf
@@ -1,0 +1,57 @@
+resource "aws_codecommit_repository" "pool_resource" {
+  repository_name = join(
+    "-",
+    [
+      "pool-resource",
+      var.deployment,
+      var.name,
+    ],
+  )
+
+  description = "Used for concourse pool resource"
+
+  default_branch = "pool"
+
+  tags = {
+    Deployment = var.deployment
+  }
+}
+
+resource "aws_iam_user" "codecommit" {
+  name = "${var.deployment}-${var.name}-codecommit"
+}
+
+resource "aws_iam_policy" "codecommit" {
+  name = "${var.deployment}-${var.name}-codecommit"
+
+  policy = <<-POLICY
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "codecommit:GitPull",
+          "codecommit:GitPush"
+        ],
+        "Effect": "Allow",
+        "Resource": "${aws_codecommit_repository.pool_resource.arn}"
+      }
+    ]
+  }
+POLICY
+}
+
+resource "aws_iam_user_policy_attachment" "codecommit_codecommit" {
+  user       = aws_iam_user.codecommit.name
+  policy_arn = aws_iam_policy.codecommit.arn
+}
+
+resource "tls_private_key" "codecommit" {
+  algorithm   = "RSA"
+}
+
+resource "aws_iam_user_ssh_key" "codecommit" {
+  username   = aws_iam_user.codecommit.name
+  encoding   = "SSH"
+  public_key = tls_private_key.codecommit.public_key_openssh
+}

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/pipeline-helpers.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/pipeline-helpers.tf
@@ -165,3 +165,33 @@ resource "aws_ssm_parameter" "concourse_worker_egress_ips" {
     Deployment = var.deployment
   }
 }
+
+resource "aws_ssm_parameter" "concourse_worker_codecommit_pool_uri" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_codecommit_pool_uri"
+
+  type        = "String"
+  description = "Clone URI for codecommit pool repo ${var.deployment}/${var.name}"
+  value       = "ssh://${
+    replace(
+      aws_codecommit_repository.pool_resource.clone_url_ssh,
+      "ssh://",
+      "${aws_iam_user_ssh_key.codecommit.ssh_public_key_id}@",
+    )
+  }"
+
+  tags = {
+    Deployment = var.deployment
+  }
+}
+
+resource "aws_ssm_parameter" "concourse_worker_codecommit_private_key" {
+  name = "/${var.deployment}/concourse/pipelines/${var.name}/readonly_codecommit_private_key"
+
+  type        = "String"
+  description = "Clone URI for codecommit pool repo ${var.deployment}/${var.name}"
+  value       = tls_private_key.codecommit.private_key_pem
+
+  tags = {
+    Deployment = var.deployment
+  }
+}


### PR DESCRIPTION
What
----

To enable teams to use the pool-resource, they need:

- a git repo
- an ssh key
- etc

this is a bit annoying to set up, as such, no one is using pools

we can terraform these for each team, so they don't have to do any work to use pools

How to review
----

We made this pipeline:

```
resource_types:
  - name: pool
    type: registry-image
    source:
      repository: concourse/pool-resource
      tag: 1.1.3

resources:
  - name: my-pool-repo
    type: git
    source:
      branch: pool
      uri: ((readonly_codecommit_pool_uri))
      private_key: ((readonly_codecommit_private_key))

  - name: a-lock-config
    type: mock
    source:
      create_files:
        name: my-lock
        metadata: ''

  - name: my-pool
    type: pool
    source:
      branch: pool
      uri: ((readonly_codecommit_pool_uri))
      private_key: ((readonly_codecommit_private_key))
      pool: my-pool

jobs:
  - name: recreate-pool
    plan:
      - task: create-pool-dirs
        config:
          platform: linux

          image_resource:
            type: registry-image
            source:
              repository: governmentpaas/git-ssh
              tag: latest

          outputs:
            - name: my-pool-repo

          run:
            dir: my-pool-repo
            path: sh
            args:
              - -c
              - |
                set -eu

                git init .

                mkdir -p my-pool/claimed
                mkdir -p my-pool/unclaimed
                touch my-pool/claimed/.keep
                touch my-pool/unclaimed/.keep

                git add my-pool
                git commit -m 'setup my-pool'

      - put: my-pool-repo
        params:
          repository: my-pool-repo
          force: true

  - name: create-lock
    plan:
      - get: a-lock-config

      - put: my-pool
        params:
          add: a-lock-config

  - name: acquire-lock
    plan:
      - get: my-pool
        passed: [create-lock]

      - put: my-pool
        params:
          acquire: true

  - name: release-lock
    plan:
      - get: my-pool
        passed: [create-lock]

      - put: my-pool
        params:
          release: my-pool

```

and deployed it to staging: https://cd-staging.gds-reliability.engineering/teams/sandbox/pipelines/pool-test