### PR TITLE
concourse: add missing release trigger

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -180,6 +180,7 @@ jobs:
       passed: [deploy]
     - get: concourse-release
       passed: [deploy]
+      trigger: true
       params:
         globs:
         - concourse-*-linux-amd64.tgz.sha1
@@ -233,6 +234,7 @@ jobs:
       passed: [scale-out]
     - get: concourse-release
       passed: [scale-out]
+      trigger: true
       params:
         globs:
         - concourse-*-linux-amd64.tgz.sha1


### PR DESCRIPTION
missing triggers on concourse-release resource prevented stages other
than "deploy" firing, making me sad that I didn't get to see a new
version of concourse waiting for me in the morning.