### PR TITLE
concourse: store worker logs

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -300,12 +300,19 @@ jobs:
       release: a-test-lock-config
 
   # check that logs are arriving in CloudWatch
-  - task: check-concourse-logs
-    file: tech-ops/reliability-engineering/pipelines/tasks/test-log-shipping.yml
-    attempts: 3
-    timeout: 10m
-    params:
-      LOG_GROUP: /((deployment_name))/concourse/web
+  - in_parallel:
+    - task: check-web-logs
+      file: tech-ops/reliability-engineering/pipelines/tasks/test-log-shipping.yml
+      attempts: 3
+      timeout: 10m
+      params:
+        LOG_GROUP: /((deployment_name))/concourse/web
+    - task: check-worker-logs
+      file: tech-ops/reliability-engineering/pipelines/tasks/test-log-shipping.yml
+      attempts: 3
+      timeout: 10m
+      params:
+        LOG_GROUP: /((deployment_name))/concourse/worker
 
 - name: tag-release
   serial: true

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
@@ -138,6 +138,17 @@ resource "aws_iam_policy" "concourse_worker_base" {
         "Effect": "Allow",
         "Action": ["ecr:GetAuthorizationToken"],
         "Resource": "*"
+      }, {
+        "Effect": "Allow",
+        "Action": [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+        ],
+        "Resource": [
+          "arn:aws:logs:*:*:*"
+        ]
       }
     ]
   }

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/launch-template.tf
@@ -14,11 +14,12 @@ data "template_file" "concourse_worker_cloud_init" {
   template = file("${path.module}/files/worker-init.sh")
 
   vars = {
-    deployment        = var.deployment
-    worker_team_name  = var.name
-    concourse_host    = local.concourse_url
-    concourse_version = var.concourse_version
-    concourse_sha1    = var.concourse_sha1
+    deployment            = var.deployment
+    worker_team_name      = var.name
+    concourse_host        = local.concourse_url
+    concourse_version     = var.concourse_version
+    concourse_sha1        = var.concourse_sha1
+    syslog_log_group_name = "/${var.deployment}/concourse/worker"
   }
 }
 

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/variables.tf
@@ -79,3 +79,4 @@ variable "concourse_sha1" {
 }
 
 data "aws_caller_identity" "account" {}
+


### PR DESCRIPTION
## What

this enables the cloudwatch agent on workers to ship logs to cloudwatch and adds a little check to the deployment pipeline to ensure they are getting shipped.

## Why

the worker logs may be useful to understand what has happened to cause a worker to disappear, but we are not currently storing the worker logs so would have to catch the worker while it's still alive.

