### PR TITLE
Create a module to configure S3 object level logging

### DIFF
--- a/cyber-security/modules/csls_s3_object_logging/README.md
+++ b/cyber-security/modules/csls_s3_object_logging/README.md
@@ -1,0 +1,44 @@
+# CSLS S3 Object Level Logging
+
+Configure object level logging on all buckets 
+in an account or a named list of buckets. 
+
+Subscribe the cloudtrail to the CSLS to deliver 
+the logs to SplunkCloud. 
+
+## Usage
+
+```
+module "s3_object_logging_test" {
+  source                     = "git::https://github.com/alphagov/tech-ops.git//cyber-security/modules/csls_s3_object_logging?ref=0b93f642678d09f5f329f4ef6b1db0258ed8fec2"
+  cloudwatch_destination_arn = "[ ask in #cyber-security-help ]"
+  logging_suffix             = ""
+  bucket_arn_list = [
+    "arn:aws:s3:::my-1st-bucket/",
+    "arn:aws:s3:::my-2nd-bucket/"
+  ]
+  tags = {
+    Add         = "your own"
+    Tags        = "to tag all the"
+    Created     = "resources"
+  }
+}
+
+```  
+
+NOTE: If individual bucket ARNS are added they must be appended with a trailing slash.
+
+### Module Variables
+
+* `cloudwatch_destination_arn` (Required):  
+    Ask in [#cyber-security-help](https://gds.slack.com/archives/CCMPJKFDK)
+* `cloudwatch_filter_pattern` (Optional): 
+    Filter events before sending to Splunk.
+* `bucket_arn_list` (Optional):  
+    The default behaviour is to monitor all buckets in the account. 
+* `logging_suffix` (Optional): 
+    The default behaviour is to label things with the account ID.
+    If you limit to specific buckets you should apply a name here. 
+* `tags` (Optional): 
+    A map of tags to apply to the deployed resources. 
+

--- a/cyber-security/modules/csls_s3_object_logging/README.md
+++ b/cyber-security/modules/csls_s3_object_logging/README.md
@@ -10,7 +10,7 @@ the logs to SplunkCloud.
 
 ```
 module "s3_object_logging_test" {
-  source                     = "git::https://github.com/alphagov/tech-ops.git//cyber-security/modules/csls_s3_object_logging?ref=0b93f642678d09f5f329f4ef6b1db0258ed8fec2"
+  source                     = "git::https://github.com/alphagov/tech-ops.git//cyber-security/modules/csls_s3_object_logging?ref=8743cc8372b896a694174d5354b6cbdd6c574005"
   cloudwatch_destination_arn = "[ ask in #cyber-security-help ]"
   logging_suffix             = ""
   bucket_arn_list = [

--- a/cyber-security/modules/csls_s3_object_logging/caller.tf
+++ b/cyber-security/modules/csls_s3_object_logging/caller.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/cyber-security/modules/csls_s3_object_logging/cloudtrail.tf
+++ b/cyber-security/modules/csls_s3_object_logging/cloudtrail.tf
@@ -1,0 +1,17 @@
+resource "aws_cloudtrail" "s3_object_logging_trail" {
+  name                          = local.cloudtrail_name
+  s3_bucket_name                = local.cloudtrail_bucket_name
+  include_global_service_events = false
+
+  tags = merge(local.tags, map("Name", local.cloudtrail_name))
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type   = "AWS::S3::Object"
+      values = var.bucket_arn_list
+    }
+  }
+}

--- a/cyber-security/modules/csls_s3_object_logging/cloudwatch.tf
+++ b/cyber-security/modules/csls_s3_object_logging/cloudwatch.tf
@@ -1,0 +1,31 @@
+data "template_file" "event_pattern" {
+  template = file("${path.module}/json/cloudwatch_event_pattern.json")
+}
+
+resource "aws_cloudwatch_event_rule" "s3_events" {
+  name        = local.cloudwatch_event_rule_name
+  description = "S3 object level logging rule"
+
+  tags = merge(local.tags, map("Name", local.cloudwatch_event_rule_name))
+
+  event_pattern = data.template_file.event_pattern.rendered
+}
+
+resource "aws_cloudwatch_event_target" "cloudwatch_target" {
+  rule      = aws_cloudwatch_event_rule.s3_events.name
+  target_id = "S3EventsLogGroup"
+  arn       = substr(aws_cloudwatch_log_group.s3_events_log_group.arn, 0, length(aws_cloudwatch_log_group.s3_events_log_group.arn) - 2)
+}
+
+resource "aws_cloudwatch_log_group" "s3_events_log_group" {
+  name = local.cloudwatch_log_group_name
+
+  tags = merge(local.tags, map("Name", local.cloudwatch_log_group_name))
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
+  name            = "csls_s3_object_logging_cloudwatch_log_subscription"
+  log_group_name  = local.cloudwatch_log_group_name
+  filter_pattern  = var.cloudwatch_filter_pattern
+  destination_arn = var.cloudwatch_destination_arn
+}

--- a/cyber-security/modules/csls_s3_object_logging/iam.tf
+++ b/cyber-security/modules/csls_s3_object_logging/iam.tf
@@ -1,0 +1,20 @@
+data "aws_iam_policy_document" "cloudwatch_event_logging_policy_doc" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["arn:aws:logs:eu-west-2:${data.aws_caller_identity.current.account_id}:log-group:${local.cloudwatch_log_group_name}:*"]
+
+    principals {
+      identifiers = ["delivery.logs.amazonaws.com", "events.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "cloudwatch_event_logging_policy" {
+  policy_document = data.aws_iam_policy_document.cloudwatch_event_logging_policy_doc.json
+  policy_name     = "TrustEventsToStoreLogEvents"
+}

--- a/cyber-security/modules/csls_s3_object_logging/json/cloudwatch_event_pattern.json
+++ b/cyber-security/modules/csls_s3_object_logging/json/cloudwatch_event_pattern.json
@@ -1,0 +1,38 @@
+{
+  "source": [
+    "aws.s3"
+  ],
+  "detail-type": [
+    "AWS API Call via CloudTrail"
+  ],
+  "detail": {
+    "eventSource": [
+      "s3.amazonaws.com"
+    ],
+    "eventName": [
+      "ListObjects",
+      "ListObjectVersions",
+      "PutObject",
+      "GetObject",
+      "HeadObject",
+      "CopyObject",
+      "GetObjectAcl",
+      "PutObjectAcl",
+      "CreateMultipartUpload",
+      "ListParts",
+      "UploadPart",
+      "CompleteMultipartUpload",
+      "AbortMultipartUpload",
+      "UploadPartCopy",
+      "RestoreObject",
+      "DeleteObject",
+      "DeleteObjects",
+      "GetObjectTorrent",
+      "SelectObjectContent",
+      "PutObjectLockRetention",
+      "PutObjectLockLegalHold",
+      "GetObjectLockRetention",
+      "GetObjectLockLegalHold"
+    ]
+  }
+}

--- a/cyber-security/modules/csls_s3_object_logging/locals.tf
+++ b/cyber-security/modules/csls_s3_object_logging/locals.tf
@@ -1,0 +1,62 @@
+# This allows you to customise the naming of the components for 2 scenarios:
+# 1. logging_suffix = [default], bucket_arn_list = [default]
+#     logs all buckets in account under a generic name
+# 2. logging_suffix = specified, bucket_arn_list = specified bucket ARNs.
+#     logs specified buckets under a specific name
+#     this is for logging a group of buckets that belong to the same service
+#     or for logging a single bucket
+
+locals {
+  # for account id = 1234..2
+  # if logging_suffix is default
+  #   "s3-object-logging-1234..2"
+  # else if logging_suffix = "my_application"
+  #   "s3-object-logging-my-application"
+  # snake case is converted to kebab case
+  cloudtrail_name = "${
+    var.logging_suffix == ""
+    ? "s3-object-logging-${data.aws_caller_identity.current.account_id}"
+    : "s3-object-logging-${replace(var.logging_suffix, "_", "-")}"
+  }"
+
+  # as above except account ID is always included in bucket name
+  # because S3 bucket names must be globally unique.
+  # if logging_suffix is default
+  #   "s3-object-logging-1234..2"
+  # else if logging_suffix = "my_application"
+  #   "s3-object-logging-1234..2-my-application"
+  # snake case is converted to kebab case
+  cloudtrail_bucket_name = "${
+    var.logging_suffix == ""
+    ? "s3-object-logging-${data.aws_caller_identity.current.account_id}"
+    : "s3-object-logging-${data.aws_caller_identity.current.account_id}-${replace(var.logging_suffix, "_", "-")}"
+  }"
+
+  # if logging_suffix is default
+  #   "s3-object-logging-rule"
+  # else if logging_suffix = "my_application"
+  #   "s3-object-logging-rule-my-application"
+  # snake case is converted to kebab case
+  cloudwatch_event_rule_name = "${
+    var.logging_suffix == ""
+    ? "s3-object-logging-rule"
+    : "s3-object-logging-rule-${replace(var.logging_suffix, "_", "-")}"
+  }"
+
+  # if logging_suffix is default
+  #   "/aws/events/s3_data_events"
+  # else if logging_suffix = "my_application"
+  #   "/aws/events/s3_data_events_my_application"
+  # kebab case is converted to snake case
+  cloudwatch_log_group_name = "${
+    var.logging_suffix == ""
+    ? "/aws/events/s3_data_events"
+    : "/aws/events/s3_data_events_${replace(var.logging_suffix, "-", "_")}"
+  }"
+
+  # allow user to specify any tagging they like and then append our tags into the map.
+  tags = merge(var.tags, map(
+    "ModuleSource", "https://github.com/alphagov/tech-ops/tree/master/cyber-security/modules/csls_s3_object_logging",
+    "ModuleOwner", "cyber.security@digital.cabinet-office.gov.uk"
+  ))
+}

--- a/cyber-security/modules/csls_s3_object_logging/s3.tf
+++ b/cyber-security/modules/csls_s3_object_logging/s3.tf
@@ -1,0 +1,34 @@
+data "aws_iam_policy_document" "s3_log_bucket_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["s3:GetBucketAcl"]
+    resources = [
+      "arn:aws:s3:::${local.cloudtrail_bucket_name}"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+  }
+
+  statement {
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    resources = [
+      "arn:aws:s3:::${local.cloudtrail_bucket_name}/AWSLogs/*"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_s3_bucket" "s3-object-logging" {
+  bucket        = local.cloudtrail_bucket_name
+  force_destroy = true
+
+  tags = merge(local.tags, map("Name", local.cloudtrail_bucket_name))
+
+  policy = data.aws_iam_policy_document.s3_log_bucket_policy.json
+}

--- a/cyber-security/modules/csls_s3_object_logging/vars.tf
+++ b/cyber-security/modules/csls_s3_object_logging/vars.tf
@@ -1,0 +1,31 @@
+variable "cloudwatch_destination_arn" {
+  type        = string
+  description = "Ask for the CSLS cloudwatch destination ARN in #cyber-security-help."
+}
+
+variable "cloudwatch_filter_pattern" {
+  type        = string
+  description = "Can be used to filter events if required."
+  default     = ""
+}
+
+variable "bucket_arn_list" {
+  type        = list(string)
+  description = "Individual bucket ARNs should be appended with a trailing /. By default log all S3 buckets in the account."
+  default = [
+    "arn:aws:s3:::"
+  ]
+}
+
+variable "logging_suffix" {
+  type        = string
+  description = "For partial logging this is appended to the trail, log bucket name and cloudwatch log group."
+  default     = ""
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to be applied to each resource."
+  default     = {}
+}
+


### PR DESCRIPTION
At the moment you can't add S3 object logging to an existing cloudtrail ARN.

I don't know whether this ^ is a limitation of AWS or Terraform.

* Create a log bucket
* Configure cloudtrail to log bucket object events to the log bucket
* Configure a cloudwatch event rule to log to cloudwatch
* Create a log susbcription for the cloudwatch log group

I've run this through `terraform` `validate` and `fmt` and I've `applied` and `destroyed` in the `security-test` account by using a relative module path instead of the git source. 

The ModuleSource URL in `locals.tf` `tags` doesn't exist yet but will once this is merged. 