### PR TITLE
gracefully shut workers down

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
@@ -53,6 +53,7 @@ Environment=CONCOURSE_GARDEN_DNS_SERVER=169.254.169.253
 Type=simple
 RestartSec=3s
 Restart=always
+KillSignal=SIGUSR2
 WorkingDirectory=/opt/concourse/worker
 TasksMax=infinity
 MemoryLimit=infinity
@@ -80,7 +81,7 @@ while sleep 5; do
         TOKEN=`curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 1800"`
     elif [[ "$HTTP_CODE" -eq 200 ]] ; then
         echo 'Interrupted: retiring concourse-worker'
-        systemd kill -s SIGUSR2 concourse-worker
+        systemctl stop concourse-worker
         exit 0
     elif [[ "$HTTP_CODE" -eq 404 ]] ; then
         echo 'Not Interrupted'


### PR DESCRIPTION
This configures the concourse-worker systemd unit to use SIGUSR2 to
stop workers.  SIGUSR2 is the "retire worker" signal - it causes the
worker to stop accepting new jobs, but finish any jobs it currently
has.

When an instance is terminated by EC2, for example during instance
rolling, systemd is used to perform a graceful shutdown of the system.
This means that, during node rolling, we will retire workers
gracefully rather than having workers just disappear while running
jobs.

This also updates the check-spot-interruption job to do a simple
`systemctl stop` instead of trying to do clever things with `systemctl
kill`.

Supersedes #122.