### PR TITLE
Correct ownership rule for /cyber-security path.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,4 +11,4 @@ reliability-engineering/pipelines/tasks/* @alphagov/re-common-cloud
 reliability-engineering/terraform/modules/concourse-* @alphagov/re-common-cloud
 
 # cyber security owners
-cyber-security/* @alphagov/reliability-engineering @alphagov/team-cybersecurity
+/cyber-security/ @alphagov/reliability-engineering @alphagov/team-cybersecurity


### PR DESCRIPTION
cyber-security/* only matches files in the immediate parent directory.
and matches any directory called cyber-security

I think what we want is anything in a sub-directory under
cyber-security but only for the root /cyber-security directory.