### PR TITLE
Fix list vs set usage

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/acm.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/acm.tf
@@ -8,15 +8,19 @@ resource "aws_acm_certificate" "concourse_public_deployment" {
 }
 
 resource "aws_route53_record" "concourse_public_deployment_cert_validation" {
-  name    = aws_acm_certificate.concourse_public_deployment.domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.concourse_public_deployment.domain_validation_options[0].resource_record_type
+  for_each = {
+    for dvo in aws_acm_certificate.concourse_public_deployment.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  name    = each.value.name
+  records = [each.value.record]
+  type    = each.value.type
   zone_id = data.aws_route53_zone.public_root.zone_id
-
-  records = [
-    aws_acm_certificate.concourse_public_deployment.domain_validation_options[0].resource_record_value,
-  ]
-
-  ttl = 60
+  ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "concourse_public_deployment" {


### PR DESCRIPTION
Sets cannot be indexed directly. Use the recommended for_each construct
instead.

Note: I'm not sure I understand how this works; copied from: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#referencing-domain_validation_options-with-for_each-based-resources