### PR TITLE
Fix route53 record creation for ACM validation

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/acm.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/acm.tf
@@ -26,6 +26,8 @@ resource "aws_route53_record" "concourse_monitoring_cert_validation" {
   type    = each.value.type
   zone_id = data.aws_route53_zone.public_root.zone_id
   ttl     = 60
+
+  allow_overwrite = true
 }
 
 resource "aws_acm_certificate_validation" "concourse_web" {

--- a/reliability-engineering/terraform/modules/concourse-web/acm.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/acm.tf
@@ -21,6 +21,8 @@ resource "aws_route53_record" "concourse_public_deployment_cert_validation" {
   type    = each.value.type
   zone_id = data.aws_route53_zone.public_root.zone_id
   ttl     = 60
+
+  allow_overwrite = true
 }
 
 resource "aws_acm_certificate_validation" "concourse_public_deployment" {


### PR DESCRIPTION
I think terraform is attempting to create a record for both the root
domain name and the subject alternate name, but in this context the CNAME
is the same, which violates terraform's default behaviour. The overwrite
is the safe workaround here, and appears in terraforms docs in this
context.