### PR TITLE
Make instance-rolling pipeline be dynamically generated with teams from Concourse

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -158,8 +158,14 @@ jobs:
       - concourse-provider-config/provider_concourse_override.tf.json
       var_files:
       - concourse-provider-config/version.tfvars
+  - task: generate-roll-instances-pipeline
+    file: tech-ops/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
+    image: fly
+    params:
+      CONCOURSE_USERNAME: main
+      CONCOURSE_PASSWORD: ((readonly_local_user_password))
   - set_pipeline: roll-instances
-    file: tech-ops-private/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))/roll-instances.yml
+    file: roll-instances-pipeline/roll-instances.yml
   - set_pipeline: deploy-info-pipelines
     file: tech-ops-private/reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))/deploy-info-pipelines.yml
     vars:

--- a/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
+++ b/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
@@ -1,0 +1,71 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: concourse/concourse-pipeline-resource
+    tag: "6.0.0"
+inputs:
+- name: tech-ops-private
+outputs:
+- name: roll-instances-pipeline
+params:
+  DEPLOYMENT_NAME:
+  CONCOURSE_USERNAME:
+  CONCOURSE_PASSWORD:
+run:
+  path: /bin/bash
+  args:
+  - -euo
+  - pipefail
+  - -c
+  - |
+    mkdir -p roll-instances-pipeline
+    fly -t concourse login -c "https://${DEPLOYMENT_NAME}.gds-reliability.engineering" -u $CONCOURSE_USERNAME -p $CONCOURSE_PASSWORD -n $CONCOURSE_USERNAME
+    fly -t concourse sync
+    fly -t concourse workers --json | jq 'group_by (.team)[] | {"team": (.[0].team), "workers": (. | length)}' | jq --slurp '{
+      "resources": [
+        {
+          "name": "every-weekday-morning",
+          "type": "time",
+          "source": {
+            "location": "Europe/London",
+            "start": "05:00 AM",
+            "stop": "06:00 AM"
+          }
+        }
+      ],
+      "jobs": [.[] | select (.team != "main") | {
+        "name": ("roll-" + .team + "-concourse-workers"),
+        "serial": true,
+        "plan": [
+          {
+            "get": "every-weekday-morning",
+            "trigger": true
+          },
+          {
+            "task": "roll-instances",
+            "config": {
+              "platform": "linux",
+              "image_resource": {
+                "type": "docker-image",
+                "source": {
+                  "repository": "gdsre/awsc",
+                  "tag": "c0e3d9fa6213"
+                }
+              },
+              "params": {
+                "TEAM": .team,
+                "MINIMUM_HEALTHY": (if (100 / .workers) == 100 then 0 else (100 / .workers) end)
+              },
+              "run": {
+                "path": "sh",
+                "args": [
+                  "-c",
+                  "set -ue; AWS_REGION=eu-west-2 awsc autoscaling migrate cd-$TEAM-concourse-worker -m $MINIMUM_HEALTHY"
+                ]
+              }
+            }
+          }
+        ]
+      }]
+    }' | yq --yaml-output . > roll-instances-pipeline/roll-instances.yml


### PR DESCRIPTION
So we stop forgetting to do things like https://github.com/alphagov/tech-ops-private/pull/417 and having to come back to them
Once this is done we should remove it from the list in re-team-manual, also do a similar thing for deploy-info-pipelines.

This will also result in different MINIMUM_HEALTHY values for verify (due to number of workers changing) and notify.