### PR TITLE
Avoid Concourse variable substitution too early

### DIFF
--- a/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
+++ b/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
@@ -30,9 +30,9 @@ run:
           "type": "git",
           "icon": "github-circle",
           "source": {
-            "branch": "((deployment_branch))",
+            "branch": ("((" + "deployment_branch" + "))"),
             "uri": "git@github.com:alphagov/tech-ops-private.git",
-            "private_key": "((re-autom8-ci-github-ssh-private-key))",
+            "private_key": ("((" + "re-autom8-ci-github-ssh-private-key" + "))"),
             "paths": [
               "reliability-engineering/terraform/deployments/gds-tech-ops/cd/pipelines/info.yml"
             ]


### PR DESCRIPTION
These should be substituted at deploy-info-pipelines pipeline set time, not at generate-deploy-info-pipelines-pipeline run time.