### PR TITLE
concourse: fix gen roll instances when workers missing

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -166,27 +166,6 @@ jobs:
       - concourse-provider-config/provider_concourse_override.tf.json
       var_files:
       - concourse-provider-config/version.tfvars
-  - get: fly-yq
-  - task: generate-roll-instances-pipeline
-    file: tech-ops/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
-    image: fly-yq
-    params:
-      DEPLOYMENT_NAME: ((deployment_name))
-      CONCOURSE_USERNAME: main
-      CONCOURSE_PASSWORD: ((readonly_local_user_password))
-  - set_pipeline: roll-instances
-    file: roll-instances-pipeline/roll-instances.yml
-  - task: generate-deploy-info-pipelines-pipeline
-    file: tech-ops/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
-    image: fly-yq
-    params:
-      DEPLOYMENT_NAME: ((deployment_name))
-      CONCOURSE_USERNAME: main
-      CONCOURSE_PASSWORD: ((readonly_local_user_password))
-  - set_pipeline: deploy-info-pipelines
-    file: deploy-info-pipelines-pipeline/deploy-info-pipelines.yml
-    vars:
-      deployment_branch: ((deployment_branch))
 
 - name: scale-out
   serial: true
@@ -273,6 +252,36 @@ jobs:
       - concourse-provider-config/provider_concourse_override.tf.json
       var_files:
       - concourse-provider-config/version.tfvars
+
+- name: configure-teams
+  serial: true
+  serial_groups: [deploy]
+  plan:
+  - in_parallel:
+    - get: tech-ops-private
+      passed: [scale-in]
+      trigger: true
+    - get: fly-yq
+  - task: generate-roll-instances-pipeline
+    file: tech-ops/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
+    image: fly-yq
+    params:
+      DEPLOYMENT_NAME: ((deployment_name))
+      CONCOURSE_USERNAME: main
+      CONCOURSE_PASSWORD: ((readonly_local_user_password))
+  - set_pipeline: roll-instances
+    file: roll-instances-pipeline/roll-instances.yml
+  - task: generate-deploy-info-pipelines-pipeline
+    file: tech-ops/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
+    image: fly-yq
+    params:
+      DEPLOYMENT_NAME: ((deployment_name))
+      CONCOURSE_USERNAME: main
+      CONCOURSE_PASSWORD: ((readonly_local_user_password))
+  - set_pipeline: deploy-info-pipelines
+    file: deploy-info-pipelines-pipeline/deploy-info-pipelines.yml
+    vars:
+      deployment_branch: ((deployment_branch))
 
 - name: test
   serial: true

--- a/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
+++ b/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
@@ -23,7 +23,15 @@ run:
     export PATH="$PATH:/opt/resource"
     fly -t concourse login -c "https://${DEPLOYMENT_NAME}.gds-reliability.engineering" -u $CONCOURSE_USERNAME -p $CONCOURSE_PASSWORD -n $CONCOURSE_USERNAME
     fly -t concourse sync
-    fly -t concourse workers --json | jq 'group_by (.team)[] | {"team": (.[0].team), "workers": (. | length)}' | jq --slurp '{
+    jq -s '.[0] * .[1]' \
+      <(fly -t concourse teams --json \
+        | jq '[.[] | {team: .name, workers: 1}]' \
+        | jq 'map( {(.team): .} ) | add' \
+      ) \
+      <(fly -t concourse workers --json \
+        | jq '[group_by (.team)[] | {"team": (.[0].team), "workers": (. | length)}]' \
+        | jq 'map( {(.team): .} ) | add' \
+      ) | jq 'to_entries | map_values(.value) | {
       "resources": [
         {
           "name": "every-weekday-morning",


### PR DESCRIPTION
if a worker is missing/dead when the deploy step runs then no "roll instances" pipeline will be created for it.

also, directly after deploy, any new workers by not be registered yet so will not get picked up.

so...

this fetches the list of teams and merges it with the list of workers to ensure that any known teams show up with at least one worker.

we also move this step to after scale-in, since teams will not be updated until concourse-web has come up and this gives much more time for new workers to have been registered