### PR TITLE
AUT-825: Update Prometheus to scrape metrics from Grafana

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
@@ -60,6 +60,17 @@ scrape_configs:
       - source_labels: [__meta_ec2_instance_id]
         target_label: instance
 
+  - job_name: concourse_grafana
+    metrics_path: '/metrics'
+    scheme: 'http'
+    dns_sd_configs:
+      - names:
+          - "${deployment}-concourse-grafana.monitoring.local"
+    relabel_configs:
+      - source_labels: [__meta_dns_name]
+        target_label: job
+        regex: "^${deployment}-concourse-(.*).monitoring.local$"
+
   - job_name: concourse_node_exporter
     ec2_sd_configs:
       - region: eu-west-2

--- a/reliability-engineering/terraform/modules/concourse-monitoring/security-groups.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/security-groups.tf
@@ -38,7 +38,7 @@ resource "aws_security_group_rule" "concourse_monitoring_lb_ingress_from_outside
   to_port   = 443
 
   security_group_id = aws_security_group.concourse_monitoring_lb.id
-  cidr_blocks       = concat(
+  cidr_blocks = concat(
     var.whitelisted_cidr_blocks,
     formatlist("%s/32", var.main_nat_gateway_egress_ips)
   )
@@ -98,6 +98,15 @@ resource "aws_security_group_rule" "concourse_grafana_egress_to_internet" {
 
   security_group_id = aws_security_group.concourse_grafana.id
   cidr_blocks       = ["0.0.0.0/0"]
+}
+
+module "concourse_prometheus_can_scrape_metrics_from_concourse_grafana" {
+  source = "../sg-access-pair"
+
+  source_sg_id      = var.prometheus_security_group_id
+  destination_sg_id = aws_security_group.concourse_grafana.id
+  from_port         = 3000
+  to_port           = 3000
 }
 
 module "concourse_prometheus_can_talk_to_concourse_grafana_over_9100" {


### PR DESCRIPTION
At this moment, Prometheus is not scraping metrics from Grafana. This change adds a service discovery to Grafana service so that Prometheus can find Grafana instance and start scraping metrics from it. This will allow us to find out how healthy Grafana is.

Author: @adityapahuja