### PR TITLE
AUT-825: Fix domain name

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
@@ -65,11 +65,11 @@ scrape_configs:
     scheme: 'http'
     dns_sd_configs:
       - names:
-          - "${deployment}-concourse-grafana.monitoring.local"
+          - "${deployment}-concourse-grafana.local.cd.gds-reliability.engineering"
     relabel_configs:
       - source_labels: [__meta_dns_name]
         target_label: job
-        regex: "^${deployment}-concourse-(.*).monitoring.local$"
+        regex: "^${deployment}-concourse-(.*).local.cd.gds-reliability.engineering$"
 
   - job_name: concourse_node_exporter
     ec2_sd_configs:

--- a/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
@@ -104,7 +104,7 @@ resource "aws_ecs_service" "concourse_grafana" {
 }
 
 resource "aws_service_discovery_private_dns_namespace" "monitoring_apps" {
-  name        = "monitoring.local"
+  name        = "local.cd.gds-reliability.engineering"
   description = "Monitoring app instances"
   vpc         = var.vpc_id
 }


### PR DESCRIPTION
According to systemd-resolved service documentation, it says, "Note that these days, it's generally recommended to avoid defining ".local" in a DNS server, as RFC6762 reserves this domain for exclusive MulticastDNS use". This change renames the domain name from "monitoring.local" to "local.cd.gds-reliability.engineering".

Author: @adityapahuja