### PR TITLE
tag govsvc/aws-ruby with the ruby version

### DIFF
--- a/reliability-engineering/pipelines/build-govsvc-docker.yml
+++ b/reliability-engineering/pipelines/build-govsvc-docker.yml
@@ -49,4 +49,6 @@ jobs:
     params:
       build: govsvc-aws-ruby-git/reliability-engineering/dockerfiles/govsvc/aws-ruby
       load_bases: [ ruby-2.6.1 ]
+      tag_file: ruby-2.6.1/tag
+      tag_as_latest: true
     get_params: {skip_download: true}


### PR DESCRIPTION
Previously we tagged with ruby and aws versions (eg 2.6.1-3.0.1) but
that's a bit weird and not very semver-y.  The ruby version feels more
important.  (Also it's much easier to just forward the ruby tag).