### PR TITLE
AUT-825: Create a new service for Big Grafana

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
@@ -76,8 +76,8 @@ resource "aws_ecs_task_definition" "concourse_grafana_task_def" {
   requires_compatibilities = ["FARGATE"]
 }
 
-resource "aws_ecs_service" "concourse_grafana" {
-  name            = "${var.deployment}-concourse-grafana"
+resource "aws_ecs_service" "concourse_grafana_v2" {
+  name            = "${var.deployment}-concourse-grafana-v2"
   cluster         = aws_ecs_cluster.concourse_grafana.name
   task_definition = aws_ecs_task_definition.concourse_grafana_task_def.arn
   launch_type     = "FARGATE"


### PR DESCRIPTION
The current service for Big Grafana has a service discovery but its details are empty. According to AWS documentation, updating existing services to configure service discovery for the first time or change the current configuration is not supported. This change deletes the current service and create a new service called <deployment>-concourse-grafana-v2 with service discovery enabled.

Author: @adityapahuja