### PR TITLE
Use new govsvc/aws-ruby image

### DIFF
--- a/reliability-engineering/pipelines/internal-apps.yml
+++ b/reliability-engineering/pipelines/internal-apps.yml
@@ -98,8 +98,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: gdsre/aws-ruby
-              tag: 2.6.1-3.0.1
+              repository: govsvc/aws-ruby
+              tag: 2.6.1
           inputs:
             - name: re-team-manual-pr
               path: repo
@@ -142,8 +142,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: gdsre/aws-ruby
-              tag: 2.6.1-3.0.1
+              repository: govsvc/aws-ruby
+              tag: 2.6.1
           inputs:
             - name: re-team-manual-git
               path: repo
@@ -190,8 +190,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: gdsre/aws-ruby
-              tag: 2.6.1-3.0.1
+              repository: govsvc/aws-ruby
+              tag: 2.6.1
           inputs:
             - name: reliability-engineering-pr
               path: repo
@@ -220,8 +220,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: gdsre/aws-ruby
-              tag: 2.6.1-3.0.1
+              repository: govsvc/aws-ruby
+              tag: 2.6.1
           inputs:
             - name: reliability-engineering-git
               path: repo
@@ -252,8 +252,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: gdsre/aws-ruby
-              tag: 2.6.1-3.0.1
+              repository: govsvc/aws-ruby
+              tag: 2.6.1
           inputs:
             - name: gds-way-pr
               path: repo
@@ -282,8 +282,8 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: gdsre/aws-ruby
-              tag: 2.6.1-3.0.1
+              repository: govsvc/aws-ruby
+              tag: 2.6.1
           inputs:
             - name: gds-way-git
               path: repo


### PR DESCRIPTION
This image is now continuously deployed, we should prefer it