### PR TITLE
Roll big concourse workers at midnight

### DIFF
--- a/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
+++ b/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
@@ -38,8 +38,8 @@ run:
           "type": "time",
           "source": {
             "location": "Europe/London",
-            "start": "05:00 AM",
-            "stop": "06:00 AM"
+            "start": "00:00 AM",
+            "stop": "01:00 AM"
           }
         }
       ],


### PR DESCRIPTION
Following a request from a tenant, change the time the workers roll to
midnight to avoid workers dying while jobs are running.