### PR TITLE
Export concourse worker asg name

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
@@ -36,3 +36,7 @@ resource "aws_autoscaling_group" "concourse_worker" {
     propagate_at_launch = true
   }
 }
+
+output "asg_name" {
+  value = aws_autoscaling_group.concourse_worker.name
+}


### PR DESCRIPTION
So it can be used in tech-ops-private for, e.g., setting autoscaling
schedules.