### PR TITLE
concourse: updates to deployment pipeline for v6.5.1

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -264,6 +264,9 @@ jobs:
       attempts: 10
       passed: [scale-in]
       trigger: true
+    - get: concourse-release
+      passed: [scale-in]
+      trigger: true
     - get: fly-yq
   - task: generate-roll-instances-pipeline
     file: tech-ops/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
@@ -302,6 +305,9 @@ jobs:
     - get: version
       attempts: 10
       params: {bump: minor}
+    - get: concourse-release
+      passed: [scale-in]
+      trigger: true
 
   # this is a simple check to ensure push to ecr works
   - put: ecr
@@ -362,6 +368,9 @@ jobs:
   plan:
   - in_parallel:
     - get: tech-ops
+      passed: [test]
+      trigger: true
+    - get: concourse-release
       passed: [test]
       trigger: true
     - get: version

--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -100,16 +100,6 @@ resources:
   source:
     owner: concourse
     repository: concourse
-- name: fly
-  type: registry-image
-  source:
-    repository: concourse/concourse-pipeline-resource
-    tag: latest
-- name: fly-yq
-  type: registry-image
-  source:
-    repository: gdsre/fly-yq
-    tag: latest
 
 jobs:
 
@@ -186,14 +176,12 @@ jobs:
       params:
         globs:
         - concourse-*-linux-amd64.tgz.sha1
-    - get: fly
   - task: configure-providers
     file: tech-ops/reliability-engineering/pipelines/tasks/concourse-provider-config.yml
     params:
       DEPLOYMENT_NAME: ((deployment_name))
   - task: get-current-workers
     file: tech-ops/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
-    image: fly
     params:
       DEPLOYMENT_NAME: ((deployment_name))
   - do:
@@ -208,7 +196,6 @@ jobs:
           ASG_PREFIX: ((deployment_name))-main-concourse-worker
     - task: land-old-workers
       file: tech-ops/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
-      image: fly
       params:
         DEPLOYMENT_NAME: ((deployment_name))
     on_failure:
@@ -267,25 +254,22 @@ jobs:
     - get: concourse-release
       passed: [scale-in]
       trigger: true
-    - get: fly-yq
   - task: generate-roll-instances-pipeline
     file: tech-ops/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
-    image: fly-yq
     params:
       DEPLOYMENT_NAME: ((deployment_name))
       CONCOURSE_USERNAME: main
       CONCOURSE_PASSWORD: ((readonly_local_user_password))
   - set_pipeline: roll-instances
-    file: roll-instances-pipeline/roll-instances.yml
+    file: roll-instances-pipeline/roll-instances.json
   - task: generate-deploy-info-pipelines-pipeline
     file: tech-ops/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
-    image: fly-yq
     params:
       DEPLOYMENT_NAME: ((deployment_name))
       CONCOURSE_USERNAME: main
       CONCOURSE_PASSWORD: ((readonly_local_user_password))
   - set_pipeline: deploy-info-pipelines
-    file: deploy-info-pipelines-pipeline/deploy-info-pipelines.yml
+    file: deploy-info-pipelines-pipeline/deploy-info-pipelines.json
     vars:
       deployment_branch: ((deployment_branch))
 

--- a/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
+++ b/reliability-engineering/pipelines/tasks/concourse-get-workers.yml
@@ -3,7 +3,9 @@ image_resource:
   type: registry-image
   source:
     repository: concourse/concourse-pipeline-resource
-    tag: 6
+    tag: dev
+  version:
+    digest: sha256:cd899511e06c3027dc8429f4b38ba8ea32a4c0bea044f4711899d5987abf8fdf
 params:
   DEPLOYMENT_NAME:
   FLY_USERNAME: main

--- a/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
+++ b/reliability-engineering/pipelines/tasks/concourse-land-workers.yml
@@ -3,7 +3,9 @@ image_resource:
   type: registry-image
   source:
     repository: concourse/concourse-pipeline-resource
-    tag: 6
+    tag: dev
+  version:
+    digest: sha256:cd899511e06c3027dc8429f4b38ba8ea32a4c0bea044f4711899d5987abf8fdf
 params:
   DEPLOYMENT_NAME:
   FLY_USERNAME: main

--- a/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
+++ b/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
@@ -3,7 +3,9 @@ image_resource:
   type: registry-image
   source:
     repository: concourse/concourse-pipeline-resource
-    tag: "6.0.0"
+    tag: dev
+  version:
+    digest: sha256:cd899511e06c3027dc8429f4b38ba8ea32a4c0bea044f4711899d5987abf8fdf
 inputs:
 - name: tech-ops-private
 outputs:

--- a/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
+++ b/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
@@ -21,6 +21,7 @@ run:
   - pipefail
   - -c
   - |
+    apk update && apk add jq
     mkdir -p deploy-info-pipelines-pipeline
     export PATH="$PATH:/opt/resource"
     fly -t concourse login -c "https://${DEPLOYMENT_NAME}.gds-reliability.engineering" -u $CONCOURSE_USERNAME -p $CONCOURSE_PASSWORD -n $CONCOURSE_USERNAME
@@ -58,4 +59,4 @@ run:
           }
         ]
       }]
-    }' | yq --yaml-output . > deploy-info-pipelines-pipeline/deploy-info-pipelines.yml
+    }' > deploy-info-pipelines-pipeline/deploy-info-pipelines.json

--- a/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
+++ b/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
@@ -3,7 +3,9 @@ image_resource:
   type: registry-image
   source:
     repository: concourse/concourse-pipeline-resource
-    tag: "6.0.0"
+    tag: dev
+  version:
+    digest: sha256:cd899511e06c3027dc8429f4b38ba8ea32a4c0bea044f4711899d5987abf8fdf
 inputs:
 - name: tech-ops-private
 outputs:

--- a/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
+++ b/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
@@ -21,6 +21,7 @@ run:
   - pipefail
   - -c
   - |
+    apk update && apk add jq
     mkdir -p roll-instances-pipeline
     export PATH="$PATH:/opt/resource"
     fly -t concourse login -c "https://${DEPLOYMENT_NAME}.gds-reliability.engineering" -u $CONCOURSE_USERNAME -p $CONCOURSE_PASSWORD -n $CONCOURSE_USERNAME
@@ -94,4 +95,4 @@ run:
           }
         ]
       }]
-    }' | yq --yaml-output . > roll-instances-pipeline/roll-instances.yml
+    }' > roll-instances-pipeline/roll-instances.json


### PR DESCRIPTION
### What

* trigger test job when concourse-release changes so the pipeline doesn't stall
* the concourse-pipeline-resource is too old ... so update that to a version with a compatible `fly`
* it's hard to find all the instances of `fly` that need updating, so remove dependency on everything except the "concourse-pipeline-resource" image

### Depends on

https://github.com/alphagov/tech-ops-private/pull/437 (which bumps terraform provider to https://github.com/alphagov/terraform-provider-concourse/pull/13)

### Testing

These branches are all currently deployed to [cd-staging](https://cd-staging.gds-reliability.engineering/teams/main/pipelines/deploy) ... pipeline there is paused until this chain of PRs is merged