### PR TITLE
Switch to concourse secretsmanager credential backend

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -91,10 +91,10 @@ ExecStart=/usr/local/concourse/bin/concourse web \
   --external-url https://${concourse_external_url} \
   --peer-address $${local_ip}                      \
   \
-  --aws-ssm-region eu-west-2 \
-  --aws-ssm-pipeline-secret-template \
+  --aws-secretsmanager-region eu-west-2 \
+  --aws-secretsmanager-pipeline-secret-template \
     /${deployment}/concourse/pipelines/{{.Team}}/{{.Pipeline}}/{{.Secret}} \
-  --aws-ssm-team-secret-template \
+  --aws-secretsmanager-team-secret-template \
     /${deployment}/concourse/pipelines/{{.Team}}/{{.Secret}} \
   \
   --postgres-database concourse             \

--- a/reliability-engineering/terraform/modules/concourse-web/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/iam.tf
@@ -33,6 +33,22 @@ resource "aws_iam_policy" "concourse_web" {
           "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/concourse/pipelines/*"
         ]
       }, {
+        "Action": [
+          "secretsmanager:ListSecrets"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+      }, {
+        "Action": [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret"
+        ],
+        "Effect": "Allow",
+        "Resource": [
+          "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.account.account_id}:secret:/${var.deployment}/concourse/pipelines/*",
+          "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.account.account_id}:secret:__concourse-health-check-??????"
+        ]
+      }, {
         "Effect": "Allow",
         "Action": [
           "kms:ListKeys",


### PR DESCRIPTION
We still use parameter store for parameters fetched in user-data (eg
db_password), we're just using secretsmanager for team/pipeline
secrets.

⚠️ _Firebreak work_