### PR TITLE
Restrict worker IPs to only be permitted from given egress IPs

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
@@ -156,9 +156,36 @@ resource "aws_iam_policy" "concourse_worker_base" {
 POLICY
 }
 
+resource "aws_iam_policy" "restrict_ips" {
+  name = "${var.deployment}-${var.name}-restrict-ips"
+
+  policy = <<-POLICY
+  {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Deny",
+         "Resource": "*",
+         "Action": "*",
+         "Condition": {
+           "NotIpAddress": {
+             "aws:SourceIp": ${jsonencode(var.egress_ips)}
+           }
+         }
+       }
+     ]
+  }
+POLICY
+}
+
 resource "aws_iam_role_policy_attachment" "concourse_worker_concourse_worker_base" {
   role       = var.worker_iam_role_name
   policy_arn = aws_iam_policy.concourse_worker_base.arn
+}
+
+resource "aws_iam_role_policy_attachment" "concourse_worker_ip_restriction" {
+  role       = var.worker_iam_role_name
+  policy_arn = aws_iam_policy.restrict_ips.arn
 }
 
 resource "aws_iam_role_policy_attachment" "concourse_worker_additional" {


### PR DESCRIPTION
This makes it so that worker roles can only be used from the egress_ips given to the worker module, reducing blast radius if the IAM credentials get leaked.

Note that this ties specific creds to specific egress IPs (so for example, gsp worker roles can only be used from gsp subnet eips).  This would mean migrating from dedicated subnets/workers to shared workers on the main subnets a bit trickier - but I think the answer is "first you add the main subnets to `egress_ips` for that module", which would both allow the role creds to work, and add the egress_ips as a pipeline variable which you would use to terraform your IP restriction in your deployed-to-account.  (Sorry if this doesn't make much sense, I'm basically saying "I think it's fine").