### PR TITLE
fix worker count panel

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse.json
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse.json
@@ -480,7 +480,7 @@
         {
           "alias": "$tag_state",
           "dsType": "influxdb",
-          "expr": "sum(concourse_workers_registered) by(state)",
+          "expr": "max(concourse_workers_registered) by(state)",
           "format": "time_series",
           "groupBy": [
             {


### PR DESCRIPTION
It currently shows the number of workers multiplied by the number of
web nodes.