### PR TITLE
concourse: increase idle timeout

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/lb.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/lb.tf
@@ -4,6 +4,7 @@ resource "aws_lb" "concourse_web" {
   load_balancer_type = "application"
   security_groups    = [aws_security_group.concourse_lb.id]
   subnets            = var.public_subnet_ids
+  idle_timeout       = 150
 
   tags = {
     Name       = "${var.deployment}-concourse-web"


### PR DESCRIPTION
we are seeing 504 responses when fetching builds.

increases the timeout at the ALB is not a "fix" for this, but it should
at least let us get the responses (and I believe get them temporarily
cached). We can then look into what is causing these requests to be so
slow.