### PR TITLE
[concourse-monitoring] capture grafana logs

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/grafana-container-def.json
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/grafana-container-def.json
@@ -65,6 +65,15 @@
         "name": "GF_SECURITY_ADMIN_PASSWORD",
         "valueFrom": "arn:aws:ssm:eu-west-2:${aws_account_id}:parameter/${deployment}/grafana/grafana-admin-password"
       }
-    ]
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "/${deployment}/grafana",
+        "awslogs-region": "eu-west-2",
+        "awslogs-stream-prefix": "grafana",
+        "awslogs-create-group": "true"
+      }
+    }
   }
 ]

--- a/reliability-engineering/terraform/modules/concourse-monitoring/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/iam.tf
@@ -106,6 +106,19 @@ resource "aws_iam_policy" "concourse_grafana_execution" {
           "kms:Decrypt"
         ],
         "Resource": "${aws_kms_key.concourse_grafana.arn}"
+      }, {
+        "Effect": "Allow",
+        "Action": [
+          "logs:CreateLogStream",
+          "logs:CreateLogGroup"
+        ],
+        "Resource": "arn:aws:logs:eu-west-2:${data.aws_caller_identity.account.account_id}:log-group:/${var.deployment}/grafana"
+      }, {
+        "Effect": "Allow",
+        "Action": [
+          "logs:PutLogEvents"
+        ],
+        "Resource": "arn:aws:logs:eu-west-2:${data.aws_caller_identity.account.account_id}:log-group:/${var.deployment}/grafana:log-stream:*"
       }
     ]
   }


### PR DESCRIPTION
Capture grafana logs into their own log group.