### PR TITLE
[concourse] only specify major engine_version

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
@@ -41,7 +41,7 @@ resource "aws_db_instance" "concourse_grafana_db" {
   allocated_storage         = 25
   storage_type              = "gp2"
   engine                    = "postgres"
-  engine_version            = "10.13"
+  engine_version            = "10"
   instance_class            = "db.t2.small"
   name                      = "grafana"
   username                  = "grafana"

--- a/reliability-engineering/terraform/modules/concourse-web/rds.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/rds.tf
@@ -22,7 +22,7 @@ resource "aws_db_instance" "concourse" {
   allocated_storage            = var.db_storage_gb
   storage_type                 = "gp2"
   engine                       = "postgres"
-  engine_version               = "10.10"
+  engine_version               = "10"
   instance_class               = var.db_instance_type
   final_snapshot_identifier    = "${var.deployment}-concourse-final"
   storage_encrypted            = true


### PR DESCRIPTION
We enable [automatic minor engine version changes][1] which means that
engine_version can change outside the lifecycle of terraform.

It's fiddly to keep it all in sync because upgrades happen in a
staggered fashion.  For example, right now cd-staging-concourse is
10.13 but cd-concourse is 10.10; for grafana it's the other way round.

The [aws provider docs][2] suggest we can specify an engine prefix to
make terraform ignore minor version changes.

[1]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html#USER_UpgradeDBInstance.Upgrading.AutoMinorVersionUpgrades
[2]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#engine_version