### PR TITLE
[concourse-monitoring] keep grafana running during deploys

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
@@ -84,8 +84,8 @@ resource "aws_ecs_service" "concourse_grafana_v2" {
   launch_type     = "FARGATE"
 
   desired_count                      = 1
-  deployment_minimum_healthy_percent = 0
-  deployment_maximum_percent         = 100
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
 
   load_balancer {
     target_group_arn = aws_lb_target_group.concourse_grafana.id


### PR DESCRIPTION
Currently, when we update grafana, we stop the old task before
starting the new task.  This is bad because:

 1. we lose grafana availability during deploys
 2. if the new task fails, we lose grafana entirely

This changes the deploy strategy to start the new task, and only then
stop the old one.