### PR TITLE
[concourse-monitoring] allow grafana to ship logs

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/iam.tf
@@ -110,15 +110,10 @@ resource "aws_iam_policy" "concourse_grafana_execution" {
         "Effect": "Allow",
         "Action": [
           "logs:CreateLogStream",
-          "logs:CreateLogGroup"
-        ],
-        "Resource": "arn:aws:logs:eu-west-2:${data.aws_caller_identity.account.account_id}:log-group:/${var.deployment}/grafana"
-      }, {
-        "Effect": "Allow",
-        "Action": [
+          "logs:CreateLogGroup",
           "logs:PutLogEvents"
         ],
-        "Resource": "arn:aws:logs:eu-west-2:${data.aws_caller_identity.account.account_id}:log-group:/${var.deployment}/grafana:log-stream:*"
+        "Resource": "*"
       }
     ]
   }


### PR DESCRIPTION
I couldn't get these permissions to work with the resource
restrictions.  Let's not be too clever here and just get it working.