### PR TITLE
fetch concourse-release every 30 minutes

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -97,6 +97,7 @@ resources:
       metadata: ''
 - name: concourse-release
   type: github-release
+  check_every: 30m
   source:
     owner: concourse
     repository: concourse


### PR DESCRIPTION
We are fetching concourse-release without authenticating to github,
which means we have a rate limit of 60 requests per hour per egress
IP.

We don't need to aggressively check for new concourse releases, so
checking twice an hour feels like more than enough.

See https://developer.github.com/v3/#:~:text=Rate%20limiting,-For%20API%20requests&text=For%20unauthenticated%20requests%2C%20the%20rate,not%20the%20user%20making%20requests.