### PR TITLE
concourse: add a service level objectives dash

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse-slo.json
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse-slo.json
@@ -16,6 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
+  "id": 21,
   "links": [],
   "panels": [
     {
@@ -73,21 +74,19 @@
           "calcs": [
             "mean"
           ],
-          "fields": "/^errorRatio$/",
+          "fields": "",
           "values": false
         }
       },
       "pluginVersion": "7.0.5",
       "targets": [
         {
-          "alias": "",
+          "alias": "ok",
           "apiMode": "Metrics",
-          "dimensions": {
-            "LoadBalancer": "app/cd-concourse-web/ba5029fcd9b9cde2"
-          },
-          "expression": "",
+          "dimensions": {},
+          "expression": "SUM(SEARCH(' {AWS/ApplicationELB,LoadBalancer} ${deployment}-concourse-web  2XX', 'Sum', 300))",
           "hide": true,
-          "id": "status5xx",
+          "id": "status2xx",
           "matchExact": true,
           "metricName": "HTTPCode_ELB_5XX_Count",
           "namespace": "AWS/ApplicationELB",
@@ -99,68 +98,32 @@
           ]
         },
         {
-          "alias": "",
-          "dimensions": {
-            "LoadBalancer": "app/cd-concourse-web/ba5029fcd9b9cde2"
-          },
-          "expression": "",
+          "alias": "err",
+          "apiMode": "Metrics",
+          "dimensions": {},
+          "expression": "SUM(SEARCH(' {AWS/ApplicationELB,LoadBalancer} ${deployment}-concourse-web  5XX', 'Sum', 300))",
           "hide": true,
-          "id": "status4xx",
+          "id": "status5xx",
           "matchExact": true,
-          "metricName": "HTTPCode_ELB_4XX_Count",
+          "metricName": "HTTPCode_ELB_5XX_Count",
           "namespace": "AWS/ApplicationELB",
           "period": "300",
           "refId": "B",
-          "region": "default",
+          "region": "eu-west-2",
           "statistics": [
             "Sum"
           ]
         },
         {
-          "alias": "",
-          "dimensions": {
-            "LoadBalancer": "app/cd-concourse-web/ba5029fcd9b9cde2"
-          },
-          "expression": "",
-          "hide": true,
-          "id": "status2xx",
-          "matchExact": true,
-          "metricName": "HTTPCode_Target_2XX_Count",
-          "namespace": "AWS/ApplicationELB",
-          "period": "300",
-          "refId": "F",
-          "region": "default",
-          "statistics": [
-            "Sum"
-          ]
-        },
-        {
-          "alias": "",
-          "dimensions": {
-            "LoadBalancer": "app/cd-concourse-web/ba5029fcd9b9cde2"
-          },
-          "expression": "",
-          "hide": true,
-          "id": "status3xx",
-          "matchExact": true,
-          "metricName": "HTTPCode_ELB_3XX_Count",
-          "namespace": "AWS/ApplicationELB",
-          "period": "300",
-          "refId": "G",
-          "region": "default",
-          "statistics": [
-            "Sum"
-          ]
-        },
-        {
-          "alias": "",
+          "alias": "availability",
           "dimensions": {},
-          "expression": "1 - status5xx / (status2xx+status3xx+status4xx+status5xx)",
+          "expression": "1 - status5xx / (status5xx + status2xx)",
+          "hide": false,
           "id": "errorRatio",
           "matchExact": true,
           "metricName": "",
           "namespace": "",
-          "period": "300",
+          "period": "",
           "refId": "C",
           "region": "default",
           "statistics": [
@@ -193,6 +156,7 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "",
+      "transparent": true,
       "type": "text"
     },
     {
@@ -258,7 +222,7 @@
       "pluginVersion": "7.0.5",
       "targets": [
         {
-          "expr": "sum(rate(concourse_http_responses_duration_seconds_bucket{le=\"0.25\"}[5m]))\n/\nsum(rate(concourse_http_responses_duration_seconds_count[5m]))\n\n",
+          "expr": "sum(rate(concourse_http_responses_duration_seconds_bucket{le=\"0.25\",status!=\"500\"}[5m]))\n/\nsum(rate(concourse_http_responses_duration_seconds_count[5m]))\n\n",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -289,6 +253,7 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "",
+      "transparent": true,
       "type": "text"
     },
     {
@@ -383,6 +348,7 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "",
+      "transparent": true,
       "type": "text"
     }
   ],
@@ -412,6 +378,6 @@
   },
   "timezone": "",
   "title": "Service Level Objectives",
-  "uid": "conc-slo",
-  "version": 1
+  "uid": "G15tIa5Gk",
+  "version": 4
 }

--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse-slo.json
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse-slo.json
@@ -318,7 +318,7 @@
       "targets": [
         {
           "expr": " 1 - sum(increase(concourse_builds_finished{status=\"errored\"}[5m])) / sum(increase(concourse_builds_finished[5m]))",
-          "interval": "",
+          "interval": "5m",
           "legendFormat": "",
           "refId": "A"
         }

--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse-slo.json
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse-slo.json
@@ -223,7 +223,7 @@
       "targets": [
         {
           "expr": "sum(rate(concourse_http_responses_duration_seconds_bucket{le=\"0.25\",status!=\"500\"}[5m]))\n/\nsum(rate(concourse_http_responses_duration_seconds_count[5m]))\n\n",
-          "interval": "",
+          "interval": "5m",
           "legendFormat": "",
           "refId": "A"
         }

--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse-slo.json
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse-slo.json
@@ -1,0 +1,417 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "service level objectives",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "CloudWatch",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "from": "",
+              "id": 0,
+              "operator": "",
+              "text": "",
+              "to": "",
+              "type": 1,
+              "value": ""
+            }
+          ],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 99
+              },
+              {
+                "color": "dark-green",
+                "value": 99.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "interval": "",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "/^errorRatio$/",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.5",
+      "targets": [
+        {
+          "alias": "",
+          "apiMode": "Metrics",
+          "dimensions": {
+            "LoadBalancer": "app/cd-concourse-web/ba5029fcd9b9cde2"
+          },
+          "expression": "",
+          "hide": true,
+          "id": "status5xx",
+          "matchExact": true,
+          "metricName": "HTTPCode_ELB_5XX_Count",
+          "namespace": "AWS/ApplicationELB",
+          "period": "300",
+          "refId": "A",
+          "region": "eu-west-2",
+          "statistics": [
+            "Sum"
+          ]
+        },
+        {
+          "alias": "",
+          "dimensions": {
+            "LoadBalancer": "app/cd-concourse-web/ba5029fcd9b9cde2"
+          },
+          "expression": "",
+          "hide": true,
+          "id": "status4xx",
+          "matchExact": true,
+          "metricName": "HTTPCode_ELB_4XX_Count",
+          "namespace": "AWS/ApplicationELB",
+          "period": "300",
+          "refId": "B",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        },
+        {
+          "alias": "",
+          "dimensions": {
+            "LoadBalancer": "app/cd-concourse-web/ba5029fcd9b9cde2"
+          },
+          "expression": "",
+          "hide": true,
+          "id": "status2xx",
+          "matchExact": true,
+          "metricName": "HTTPCode_Target_2XX_Count",
+          "namespace": "AWS/ApplicationELB",
+          "period": "300",
+          "refId": "F",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        },
+        {
+          "alias": "",
+          "dimensions": {
+            "LoadBalancer": "app/cd-concourse-web/ba5029fcd9b9cde2"
+          },
+          "expression": "",
+          "hide": true,
+          "id": "status3xx",
+          "matchExact": true,
+          "metricName": "HTTPCode_ELB_3XX_Count",
+          "namespace": "AWS/ApplicationELB",
+          "period": "300",
+          "refId": "G",
+          "region": "default",
+          "statistics": [
+            "Sum"
+          ]
+        },
+        {
+          "alias": "",
+          "dimensions": {},
+          "expression": "1 - status5xx / (status2xx+status3xx+status4xx+status5xx)",
+          "id": "errorRatio",
+          "matchExact": true,
+          "metricName": "",
+          "namespace": "",
+          "period": "300",
+          "refId": "C",
+          "region": "default",
+          "statistics": [
+            "Average"
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Availability",
+      "type": "stat"
+    },
+    {
+      "content": "\n# Concourse Availability\n\nWe monitor the ratio of successful vs \nfailure HTTP status\ncodes from the load balancer that sits\nin front of the concourse-web nodes.\n\nThis is a good proxy for if the concourse\nUI/API is up and available for use.\n\n**We aim for 99.9% of requests to\nsucceed over a 7day period.**\n\n\n\n\n",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 0
+      },
+      "id": 12,
+      "mode": "markdown",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": null,
+      "description": "Percentage of requests faster than 250ms",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 2,
+          "mappings": [
+            {
+              "from": "",
+              "id": 0,
+              "operator": "",
+              "text": "",
+              "to": "",
+              "type": 1,
+              "value": ""
+            }
+          ],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 95
+              },
+              {
+                "color": "dark-green",
+                "value": 99
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.5",
+      "targets": [
+        {
+          "expr": "sum(rate(concourse_http_responses_duration_seconds_bucket{le=\"0.25\"}[5m]))\n/\nsum(rate(concourse_http_responses_duration_seconds_count[5m]))\n\n",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Responsiveness",
+      "type": "stat"
+    },
+    {
+      "content": "\n# Concourse Responsiveness\n\nWe monitor the response times of calls\nto the Concourse API.\n\nHigh latency in these response times\ncan be an indicator that users are seeing\ndegraded performance in a number of areas\nsuch as sluggish UI, slow job triggering,\npoor build performance.\n\n**We aim for 99% of API requests to \nrespond within 250ms over a 7day period**\n\n\n",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 8
+      },
+      "id": 16,
+      "mode": "markdown",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": null,
+      "description": "Percentage of builds that did not error",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "from": "",
+              "id": 0,
+              "operator": "",
+              "text": "",
+              "to": "",
+              "type": 1,
+              "value": ""
+            }
+          ],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 99
+              },
+              {
+                "color": "dark-green",
+                "value": 99.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 16
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.5",
+      "targets": [
+        {
+          "expr": " 1 - sum(increase(concourse_builds_finished{status=\"errored\"}[5m])) / sum(increase(concourse_builds_finished[5m]))",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Activity",
+      "type": "stat"
+    },
+    {
+      "content": "\n# Concourse Activity\n\nWe monitor the number of builds \n(job execute runs) that get\nprocessed without erroring.\n\nWhile there are several cases where\nerrored (orange) builds can be caused\nby users themselves, it is common that\nthese error states are caused by problems\nsuch as worker-nodes disappearing, \ncontainers being unable to get scheduled\nand configuration issues that cannot\nbe resolved by the user.\n\n**We aim for 99.9% of builds \nto be successfully processed\nwithin a 7day period.**\n\n\n\n",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 16
+      },
+      "id": 14,
+      "mode": "markdown",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Service Level Objectives",
+  "uid": "conc-slo",
+  "version": 1
+}

--- a/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
@@ -160,6 +160,7 @@ locals {
     "alerts",
     "concourse",
     "concourse-internal",
+    "concourse-slo",
     "grafana-metrics",
     "metrics-by-team"
   ]

--- a/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
@@ -156,17 +156,30 @@ resource "grafana_data_source" "cloudwatch" {
 }
 
 locals {
-  grafana_dashboards = [
+  grafana_dashboards = toset([
     "alerts",
     "concourse",
     "concourse-internal",
     "concourse-slo",
     "grafana-metrics",
     "metrics-by-team"
-  ]
+  ])
 }
+
+data "template_file" "grafana_dashboards" {
+  for_each = local.grafana_dashboards
+  template = file("${path.module}/files/dashboards/${each.key}.json")
+
+  vars = {
+    deployment = var.deployment
+  }
+}
+
 resource "grafana_dashboard" "metrics" {
-  for_each    = toset(local.grafana_dashboards)
-  config_json = file("${path.module}/files/dashboards/${each.key}.json")
-  depends_on  = [grafana_data_source.prom_data_source[0]]
+  for_each    = local.grafana_dashboards
+  config_json = template_file.grafana_dashboards[each.key].rendered
+  depends_on = [
+    grafana_data_source.prom_data_source[0],
+    grafana_data_source.cloudwatch,
+  ]
 }


### PR DESCRIPTION
## What

we want to know if we are providing a good service and when we should be
focusing on improving concourse's performance/relieability

we are tracking 3x service level indicators:

* Availability (based on the ratio of succesful/failed requests from the
  load balancer)
* Responsiveness (based on API latency)
* Activity (based on successful progressing of jobs/builds)

Combined these indicators should give us a broad picture of what
experience our users/tenants are seeing.

We have picked some initial service level objectives for these
indicators:

* We aim for 99.9% of requests through the load-balancer to succeed over
  a 7day period
* We aim for a 99% of API requests to respond within 250ms over a 7day
  period
* We aim for 99.9% of builds to be processed without error over a 7day
  period

We are not yet alerting on these SLOs

## Preview

![grafana-slo](https://user-images.githubusercontent.com/45921/95882032-1f264780-0d71-11eb-8943-ef0e7db7b45f.png)

Note: we are breaching our SLO over the last 7days in the screenshot above due to the large period of interruption during the incident last week. So nice to see it go yellow :yellow_circle: 