### PR TITLE
apt-get upgrade as well as update on instance startup

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -4,6 +4,7 @@ set -ueo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update --yes
+apt-get upgrade --yes
 
 export AWS_REGION=eu-west-2
 export AWS_DEFAULT_REGION=eu-west-2

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
@@ -4,6 +4,7 @@ set -ueo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update --yes
+apt-get upgrade --yes
 
 export AWS_REGION=eu-west-2
 export AWS_DEFAULT_REGION=eu-west-2


### PR DESCRIPTION
For the Concourse web and worker nodes. Just like the
prometheus-init.sh script does.