### PR TITLE
Fix concourse-monitoring syntax

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/grafana.tf
@@ -166,18 +166,11 @@ locals {
   ])
 }
 
-data "template_file" "grafana_dashboards" {
-  for_each = local.grafana_dashboards
-  template = file("${path.module}/files/dashboards/${each.key}.json")
-
-  vars = {
-    deployment = var.deployment
-  }
-}
-
 resource "grafana_dashboard" "metrics" {
-  for_each    = local.grafana_dashboards
-  config_json = template_file.grafana_dashboards[each.key].rendered
+  for_each = local.grafana_dashboards
+  config_json = templatefile("${path.module}/files/dashboards/${each.key}.json", {
+    deployment = var.deployment
+  })
   depends_on = [
     grafana_data_source.prom_data_source[0],
     grafana_data_source.cloudwatch,


### PR DESCRIPTION
this broke because we had `template_file.grafana_dashboards` where we
wanted `data.template_file.grafana_dashboards`.  Since I'm changing
this anyway, I'm adopting the new 0.12 `templatefile` function, which
is now recommended instead of `template_file` data sources.

https://trello.com/c/1deo6jtY/864-introduce-reliability-metrics-for-big-concourse