### PR TITLE
BAU: Deploy GDS Way from main branch

### DIFF
--- a/reliability-engineering/pipelines/internal-apps.yml
+++ b/reliability-engineering/pipelines/internal-apps.yml
@@ -15,7 +15,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/gds-way.git
-      branch: master
+      branch: main
 
   - name: re-request-an-aws-account-git
     type: git


### PR DESCRIPTION
This is part of the work to change GDS Way's default branch from `master` to `main`

This will be merged once the new branch exists, to avoid breaking the deploy process.