### PR TITLE
govsvc/aws-terraform: build aws-terraform image tracking hasicorp/terraform versions

### DIFF
--- a/reliability-engineering/dockerfiles/govsvc/aws-terraform/Dockerfile
+++ b/reliability-engineering/dockerfiles/govsvc/aws-terraform/Dockerfile
@@ -1,0 +1,17 @@
+ARG ubuntu_digest
+ARG terraform_digest
+ARG terraform_version
+
+FROM hashicorp/terraform@${terraform_digest} as terraform
+FROM ubuntu@${ubuntu_digest}
+
+LABEL terraform="${terraform_version}"
+
+RUN apt-get update  --yes && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes awscli jq curl dnsutils unzip git
+
+WORKDIR /tmp
+
+COPY --from=terraform /bin/terraform /bin/terraform
+
+ENTRYPOINT ["bash"]

--- a/reliability-engineering/pipelines/build-govsvc-docker.yml
+++ b/reliability-engineering/pipelines/build-govsvc-docker.yml
@@ -71,6 +71,31 @@ resources:
     paths:
     - reliability-engineering/dockerfiles/govsvc/awsc
 
+- name: ubuntu
+  type: docker-image
+  source:
+    repository: ubuntu
+
+- name: terraform
+  type: docker-image
+  source:
+    repository: hashicorp/terraform
+
+- name: govsvc-aws-terraform
+  type: docker-image
+  source:
+    username: ((dockerhub-username))
+    password: ((dockerhub-password))
+    repository: govsvc/aws-terraform
+
+- name: govsvc-aws-terraform-git
+  type: git
+  source:
+    uri: https://github.com/alphagov/tech-ops.git
+    branch: master
+    paths:
+    - reliability-engineering/dockerfiles/govsvc/aws-terraform
+
 jobs:
 - name: selfupdate
   serial: true
@@ -95,6 +120,52 @@ jobs:
       tag_file: ruby-2.6.1/tag
       tag_as_latest: true
     get_params: {skip_download: true}
+
+- name: build-govsvc-aws-terraform
+  serial: true
+  plan:
+  - in_parallel:
+    - get: govsvc-aws-terraform-git
+      trigger: true
+    - get: terraform
+      trigger: true
+      params: {save: true}
+    - get: ubuntu
+      params: {save: true}
+  - task: generate-version-args
+    image: terraform
+    config:
+      platform: linux
+      inputs:
+      - name: ubuntu
+      - name: terraform
+      outputs:
+      - name: versions
+      run:
+        path: ash
+        args:
+        - -eu
+        - -c
+        - |
+          mkdir -p versions
+          terraform version | head -n1 | cut -d' ' -f2 | cut -d'v' -f2 > versions/terraform_version
+          cat <<EOF > versions/args
+          {
+            "ubuntu_digest": "$(cat ubuntu/digest)",
+            "terraform_digest": "$(cat terraform/digest)",
+            "terraform_version": "$(cat versions/terraform_version)"
+          }
+          EOF
+          cat versions/*
+  - put: govsvc-aws-terraform
+    params:
+      build: govsvc-aws-terraform-git/reliability-engineering/dockerfiles/govsvc/aws-terraform
+      load_bases: [ ubuntu, terraform ]
+      tag_file: versions/terraform_version
+      tag_as_latest: true
+      build_args_file: versions/args
+    get_params: {skip_download: true}
+
 - name: build-govsvc-octodns
   serial: true
   plan:


### PR DESCRIPTION
## What

Add a build job to automate building of the `govsvc/aws-terraform` image that was previously built/pushed by hand to the `gdsre/aws-terraform` repository. and is used in numerous concourse pipelines for applying terraform.

This job will:

* Watch for releases of the hashicorp/terraform docker image
* Trigger a build that pulls latest version of ubuntu, installs aws-cli tools and copies in the tracked terraform binary
* pushes to a `govsvc/aws-terraform` image

This will result in a new image being built roughly each time a new terraform version is released.

I have run the pipeline a few times with manual versions pinned to re-build images for 0.11.13, 0.12.7 and 0.12.19 using this method as these appear to be in use. Follow up PRs will move existing uses of the `gdsre` image --> `govsvc`.

I decided to not explicitly re-build image when new versions of `ubuntu` image appears (the base image) as I'd prefer to treat tags as immutable (even tho they are not).

Pipeline is currently set by hand for testing: https://cd.gds-reliability.engineering/teams/autom8/pipelines/build-govsvc-docker should still be visible unless a merge has reset it back to master since.