### PR TITLE
Reboot machines on init

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
@@ -105,5 +105,6 @@ if [ -d $promvar ]; then
 fi
 
 systemctl daemon-reload
-systemctl enable  prometheus
-systemctl restart prometheus
+systemctl enable prometheus
+
+reboot

--- a/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-web/files/web-init.sh
@@ -147,11 +147,9 @@ EOF
 
 systemctl daemon-reload
 systemctl enable concourse-web
-systemctl start  concourse-web
 
 apt-get install --yes prometheus-node-exporter
 systemctl enable prometheus-node-exporter
-systemctl start prometheus-node-exporter
 
 ## install cloudwatch log agent
 curl -o /root/amazon-cloudwatch-agent.deb https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb
@@ -184,4 +182,5 @@ EOF
 
 # start cloudwatch log agent
 systemctl enable amazon-cloudwatch-agent.service
-service amazon-cloudwatch-agent start
+
+reboot

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/files/worker-init.sh
@@ -109,15 +109,15 @@ WantedBy=multi-user.target
 EOF
 
 systemctl daemon-reload
-systemctl enable --now concourse-worker
-systemctl enable --now check-spot-interruption
+systemctl enable concourse-worker
+systemctl enable check-spot-interruption
 
 # this enables the workers to talk to the internet
 # see concourse/concourse #1667 and #2482
 iptables -P FORWARD ACCEPT
 
 apt-get install --yes prometheus-node-exporter
-systemctl enable --now prometheus-node-exporter
+systemctl enable prometheus-node-exporter
 
 ## install cloudwatch log agent
 curl -o /root/amazon-cloudwatch-agent.deb https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb
@@ -150,4 +150,5 @@ EOF
 
 # start cloudwatch log agent
 systemctl enable amazon-cloudwatch-agent.service
-service amazon-cloudwatch-agent start
+
+reboot


### PR DESCRIPTION
To ensure they're running up to date software, in the case where it
was updated as part of the init process.

Rather than having services start, then stop because of the reboot,
this also changes the init process to just enable services, so that
they'll be first started after the reboot.