### PR TITLE
provide STS credentials via parameter store

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-keys/sts-rotation-lambda.tf
+++ b/reliability-engineering/terraform/modules/concourse-keys/sts-rotation-lambda.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_role" "concourse_sts_rotation_lambda_execution" {
+  name               = "${var.deployment}-sts-rotation-lambda-execution"
+  assume_role_policy = <<-ARP
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Principal": {
+          "Service": "lambda.amazonaws.com"
+        },
+        "Effect": "Allow"
+      }
+    ]
+  }
+ARP
+}
+
+output "concourse_sts_rotation_lambda_role_arn" {
+  value = aws_iam_role.concourse_sts_rotation_lambda_execution.arn
+}
+
+output "concourse_sts_rotation_lambda_role_name" {
+  value = aws_iam_role.concourse_sts_rotation_lambda_execution.name
+}

--- a/reliability-engineering/terraform/modules/concourse-keys/worker.tf
+++ b/reliability-engineering/terraform/modules/concourse-keys/worker.tf
@@ -40,6 +40,12 @@ resource "aws_iam_role" "concourse_workers" {
           "Service": "ec2.amazonaws.com"
         },
         "Effect": "Allow"
+      }, {
+        "Action": "sts:AssumeRole",
+        "Principal": {
+          "AWS": "${aws_iam_role.concourse_sts_rotation_lambda_execution.arn}"
+        },
+        "Effect": "Allow"
       }
     ]
   }
@@ -48,4 +54,8 @@ ARP
 
 output "concourse_worker_iam_role_names" {
   value = zipmap(var.worker_team_names, aws_iam_role.concourse_workers.*.name)
+}
+
+output "concourse_worker_iam_role_arns" {
+  value = zipmap(var.worker_team_names, aws_iam_role.concourse_workers.*.arn)
 }

--- a/reliability-engineering/terraform/modules/concourse-team-iam-credentials/.gitignore
+++ b/reliability-engineering/terraform/modules/concourse-team-iam-credentials/.gitignore
@@ -1,0 +1,1 @@
+/files/lambda_rotate_sts.zip

--- a/reliability-engineering/terraform/modules/concourse-team-iam-credentials/cred-rotation.tf
+++ b/reliability-engineering/terraform/modules/concourse-team-iam-credentials/cred-rotation.tf
@@ -1,0 +1,62 @@
+data "archive_file" "sts_lambda_function_py" {
+  type        = "zip"
+  output_path = "${path.module}/files/lambda_rotate_sts.zip"
+
+  source {
+    content  = file("${path.module}/files/lambda_rotate_sts.py")
+    filename = "lambda_function.py"
+  }
+}
+
+resource "aws_lambda_function" "sts_creds_to_ssm" {
+  filename         = data.archive_file.sts_lambda_function_py.output_path
+  source_code_hash = data.archive_file.sts_lambda_function_py.output_base64sha256
+  function_name    = "${var.deployment}_sts_creds_to_ssm"
+
+  role        = var.lambda_execution_role_arn
+  handler     = "lambda_function.lambda_handler"
+  runtime     = "python3.7"
+  timeout     = "240"
+  memory_size = "128"
+  description = "Assumes a given role and puts the resulting STS credentials into parameter store for concourse teams to use"
+
+  kms_key_arn = var.kms_key_arn
+  environment {
+    variables = {
+      DEPLOYMENT = var.deployment
+      KEY_ID     = var.kms_key_id
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "every_ten_minutes" {
+  name                = "every-ten-minutes"
+  description         = "Fires every 10 minutes"
+  schedule_expression = "rate(10 minutes)"
+}
+
+resource "aws_cloudwatch_event_target" "update_sts" {
+  rule = aws_cloudwatch_event_rule.every_ten_minutes.name
+  arn  = aws_lambda_function.sts_creds_to_ssm.arn
+
+  for_each = var.team_role_arns
+
+  target_id = each.key
+  input = jsonencode({
+    team_name = each.key
+    role_arn  = each.value
+  })
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_sts_creds_to_ssm" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.sts_creds_to_ssm.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.every_ten_minutes.arn
+}
+
+resource "aws_cloudwatch_log_group" "sts_lambda" {
+  name              = "/aws/lambda/${aws_lambda_function.sts_creds_to_ssm.function_name}"
+  retention_in_days = 7
+}

--- a/reliability-engineering/terraform/modules/concourse-team-iam-credentials/files/lambda_rotate_sts.py
+++ b/reliability-engineering/terraform/modules/concourse-team-iam-credentials/files/lambda_rotate_sts.py
@@ -1,0 +1,48 @@
+import boto3
+import json
+import os
+
+print('Loading function')
+
+ssm = boto3.client('ssm')
+sts = boto3.client('sts')
+
+
+def lambda_handler(event, context):
+    print("Received event: " + json.dumps(event, indent=2))
+
+    deployment = os.environ.get('DEPLOYMENT')
+    key_id = os.environ.get('KEY_ID')
+    role_arn = event['role_arn']
+    team_name = event['team_name']
+    parameter_prefix = "/{}/concourse/pipelines/{}".format(deployment,team_name)
+    try:
+        sts_response = sts.assume_role(
+            RoleArn=role_arn,
+            RoleSessionName='ConcourseTeam-' + team_name,
+        )
+        ssm.put_parameter(
+            Name=parameter_prefix + '/readonly_access_key_id',
+            Value=sts_response['Credentials']['AccessKeyId'],
+            Type='SecureString',
+            KeyId=key_id,
+            Overwrite=True,
+        )
+        ssm.put_parameter(
+            Name=parameter_prefix + '/readonly_secret_access_key',
+            Value=sts_response['Credentials']['SecretAccessKey'],
+            Type='SecureString',
+            KeyId=key_id,
+            Overwrite=True,
+        )
+        ssm.put_parameter(
+            Name=parameter_prefix + '/readonly_session_token',
+            Value=sts_response['Credentials']['SessionToken'],
+            Type='SecureString',
+            KeyId=key_id,
+            Overwrite=True,
+        )
+    except Exception as e:
+        print(e)
+        raise e
+

--- a/reliability-engineering/terraform/modules/concourse-team-iam-credentials/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-team-iam-credentials/iam.tf
@@ -1,0 +1,57 @@
+resource "aws_iam_policy" "concourse_sts_rotation_lambda_execution" {
+  name = "${var.deployment}-concourse-sts-rotation-lambda-execution"
+
+  policy = <<-POLICY
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "ssm:PutParameter"
+        ],
+        "Effect": "Allow",
+        "Resource": [
+          "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/concourse/pipelines/*/readonly_access_key_id",
+          "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/concourse/pipelines/*/readonly_secret_access_key",
+          "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/concourse/pipelines/*/readonly_session_token"
+        ]
+      }, {
+        "Effect": "Allow",
+        "Action": [
+          "kms:ListKeys",
+          "kms:ListAliases",
+          "kms:Describe*",
+          "kms:Decrypt",
+          "kms:Encrypt"
+        ],
+        "Resource": [
+          "${var.kms_key_arn}"
+        ]
+      }, {
+        "Effect": "Allow",
+        "Action": [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+        ],
+        "Resource": [
+          "arn:aws:logs:*:*:*"
+        ]
+      }, {
+        "Effect": "Allow",
+        "Action": [
+          "sts:AssumeRole"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "concourse_sts_rotation_lambda_execution" {
+  role       = var.lambda_execution_role_name
+  policy_arn = aws_iam_policy.concourse_sts_rotation_lambda_execution.arn
+}
+

--- a/reliability-engineering/terraform/modules/concourse-team-iam-credentials/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-team-iam-credentials/variables.tf
@@ -1,0 +1,28 @@
+variable "deployment" {
+  type = string
+}
+
+variable "lambda_execution_role_arn" {
+  type        = string
+  description = "The ARN of an IAM Role to act as execution role for the Lambda that rotates team credentials.  It needs to be trusted to assume the various team roles."
+}
+
+variable "lambda_execution_role_name" {
+  type        = string
+  description = "The name of an IAM Role to act as execution role for the Lambda that rotates team credentials.  It needs to be trusted to assume the various team roles."
+}
+
+variable "team_role_arns" {
+  type        = map(string)
+  description = "A map from team names to IAM Role ARNs representing that team."
+}
+
+variable "kms_key_id" {
+  type = string
+}
+
+variable "kms_key_arn" {
+  type = string
+}
+
+data "aws_caller_identity" "account" {}

--- a/reliability-engineering/terraform/modules/concourse-web/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/variables.tf
@@ -47,7 +47,8 @@ variable "worker_pool_egress_eips" {
 }
 
 variable "worker_ssh_public_keys_openssh" {
-  type = map(string)
+  type        = map(string)
+  description = "A map from team names to authorized_keys content for workers pinned to a specific team."
 }
 
 variable "web_ssh_private_key_pem" {

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/keys.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/keys.tf
@@ -14,7 +14,7 @@ resource "aws_ssm_parameter" "concourse_worker_web_ssh_public_key" {
   name = "/${var.deployment}/concourse/worker/${var.name}/web_ssh_public_key"
 
   type        = "SecureString"
-  description = "Concourse worker ssh private key"
+  description = "Concourse worker ssh public key"
   key_id      = var.kms_key_id
   value       = var.web_ssh_public_key_openssh
 


### PR DESCRIPTION
This PR was spun out of #163, keeping only the STS bit and dropping
the shared workers bit.

This adds a new module concourse-team-iam-credentials, which creates
new concourse variables `readonly_access_key_id`,
`readonly_secret_access_key` and `readonly_session_token`.  These
provide AWS credentials for a role session for the worker
role (exactly the same as you get from the metadata service).

This works by using a lambda function, triggered every 10 minutes, to
call sts:AssumeRole on the worker role and shove the credentials into
parameter store.

There are a few uses:

Use native concourse resource types
-----------------------------------

We have forked a bunch of concourse resource types in order to allow
them to use the instance metadata service.  Concourse is
philosophically opposed to this sort of thing; credentials should be
passed into the resource via vars, they shouldn't be ambiently
available just because you run on a particular worker.

In particular we could stop using these forks and use upstream
instead:

 - https://github.com/alphagov/paas-s3-resource
 - https://github.com/alphagov/paas-semver-resource

Pave the way for sharing workers between teams
----------------------------------------------

In future we could use this to have a single class of worker that
hosts multiple teams jobs.  The teams would still have access to their
own roles via these concourse vars, and would not be able to access
each others' roles because they would not have access to each others'
vars.  To see what this might look like, look at #163.

https://trello.com/c/XWFpsaIE/997-adopt-new-credentials-for-big-concourse-finishing-off-phils-firebreak