### PR TITLE
Use the builtin semver resource

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -7,11 +7,6 @@ resource_types:
   source:
     repository: ljfranklin/terraform-resource
     tag: 0.12.25
-- name: paas-semver
-  type: docker-image
-  source:
-    repository: governmentpaas/semver-resource
-    tag: latest
 - name: pool
   type: registry-image
   source:
@@ -63,9 +58,12 @@ resources:
       region: eu-west-2
       key: ((deployment_name)).tfstate
 - name: version
-  type: paas-semver
+  type: semver
   source:
     driver: s3
+    access_key_id: ((readonly_access_key_id))
+    secret_access_key: ((readonly_secret_access_key))
+    session_token: ((readonly_session_token))
     key: ((deployment_name))-version
     bucket: ((readonly_private_bucket_name))
     region_name: eu-west-2


### PR DESCRIPTION
Now that https://github.com/alphagov/tech-ops-private/pull/450 has
been merged, we can use the new AWS creds vars.  This means we can
stop using paas-semver and use the builtin semver resource instead.

https://trello.com/c/XWFpsaIE/997-adopt-new-credentials-for-big-concourse-finishing-off-phils-firebreak