### PR TITLE
Mark self-updating-pipeline.yml as deprecated

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-07-06T13:53:46Z",
+  "generated_at": "2020-11-09T15:12:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -63,7 +63,7 @@
         "hashed_secret": "1d4bfd13efde0cce38af417b2c8fdb36776f179f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 29,
         "type": "Secret Keyword"
       }
     ],

--- a/ci/tasks/self-updating-pipeline.md
+++ b/ci/tasks/self-updating-pipeline.md
@@ -1,5 +1,11 @@
 ## Self updating pipeline
 
+**Deprecated**
+
+This step is deprecated, you should use the [set_pipeline step][] instead now.
+
+[set_pipeline step]: https://concourse-ci.org/jobs.html#schema.step.set-pipeline-step.set_pipeline
+
 The intention is for the pipelines to be able to self update.
 
 The task will validate the pipeline before applying.

--- a/ci/tasks/self-updating-pipeline.yaml
+++ b/ci/tasks/self-updating-pipeline.yaml
@@ -22,6 +22,9 @@ run:
   args:
   - -uec
   - |
+    echo "This reusable pipeline step is deprecated, you should use the builtin set_pipeline step instead now:"
+    echo https://concourse-ci.org/jobs.html#schema.step.set-pipeline-step.set_pipeline
+
     : ${CONCOURSE_TEAM:?}
     : ${CONCOURSE_PASSWORD:?}
     : ${PIPELINE_PATH:?}


### PR DESCRIPTION
This was added before the `set_pipeline` step was really a thing.
We'd rather teams used the builtin feature, because:

 - it's one less thing for us to maintain
 - it handles auth for us (we don't need a local user)

(If this gets merged, we should inform GovWifi who are the only ones who use this.)