### PR TITLE
concourse-monitoring: make terraform 0.13 compliant

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/variables.tf
@@ -6,6 +6,10 @@ variable "vpc_id" {
   type = string
 }
 
+variable "grafana_admin_password" {
+  type = string
+}
+
 variable "private_subnet_ids" {
   type = list(string)
 }

--- a/reliability-engineering/terraform/modules/concourse-monitoring/versions.tf
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    grafana = {
+      source = "grafana/grafana"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+    template = {
+      source = "hashicorp/template"
+    }
+  }
+  required_version = ">= 0.13"
+}
+


### PR DESCRIPTION
https://trello.com/c/T3Oc4oce

Associated PR https://github.com/alphagov/tech-ops-private/pull/464

The main thing here is the need to move the grafana provider out of the module, which requires the admin password be set/generated in the root module too. Therefore we take this as a new var to be passed in.

Though the terraform 0.13 upgrade guide seems quite insistent that provider requirements belong in the root module, we appear to need to provide the `versions.tf` file, here autogenerated by the `terraform 0.13upgrade` command, to map the namespaced providers to their local in-module names otherwise terraform is unhappy.

And because the grafana provider's url is hard coded (elsewhere) and no longer restricted by the dependency graph, we add some manual `depends_on` settings to those resources that use the grafana provider so as there isn't an attempt to put them in place before the grafana instances are actually up.

Still needing discussion: how to merge this without upsetting `cd` itself, which also references this module. Maybe just keep this on a branch until we're ready to upgrade `cd` too.