### PR TITLE
concourse-deployer pipeline: use terraform 0.13.5

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -6,7 +6,7 @@ resource_types:
   type: registry-image
   source:
     repository: ljfranklin/terraform-resource
-    tag: 0.12.25
+    tag: 0.13.5
 - name: paas-semver
   type: docker-image
   source:


### PR DESCRIPTION
I should have included this in https://github.com/alphagov/tech-ops/pull/198 but didn't and now concourse is sad.