### PR TITLE
[cd] ensure cloudwatch event rules are namespaced

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-team-iam-credentials/cred-rotation.tf
+++ b/reliability-engineering/terraform/modules/concourse-team-iam-credentials/cred-rotation.tf
@@ -30,7 +30,7 @@ resource "aws_lambda_function" "sts_creds_to_ssm" {
 }
 
 resource "aws_cloudwatch_event_rule" "every_ten_minutes" {
-  name                = "every-ten-minutes-${each.key}"
+  name                = "${var.deployment}-every-ten-minutes-${each.key}"
   description         = "Fires every 10 minutes"
   schedule_expression = "rate(10 minutes)"
 


### PR DESCRIPTION
I hit a problem where `main` team credentials weren't being rotated
correctly in prod.  This turned out to be because the `cd-staging`
deployment had clobbered the cloudwatch event rule that triggers
credential refresh for `main` and `sandbox` teams.  (Other teams don't
exist in `cd-staging` so were not affected.)

This adds `var.deployment` to the event rule name so that it doesn't
clobber things.

Once this is merged we can revert #199 to use builtin semver resource again.