### PR TITLE
[cd] set MinHealthyPercentage=100

### DIFF
--- a/reliability-engineering/pipelines/tasks/asg-refresh-instances.yml
+++ b/reliability-engineering/pipelines/tasks/asg-refresh-instances.yml
@@ -18,7 +18,7 @@ run:
     function refresh_instances() {
       refresh_id=$(aws autoscaling start-instance-refresh \
         --auto-scaling-group-name "${ASG_NAME}" \
-        --preferences InstanceWarmup=120 \
+        --preferences InstanceWarmup=120,MinHealthyPercentage=100 \
         | jq -r '.InstanceRefreshId')
       echo "${refresh_id}" > refresh/id
     }


### PR DESCRIPTION
Instance Refresh has a habit of terminating our only `main` worker.
This breaks everything, because then web can't schedule any tasks.

The default MinHealthyPercentage is 90.  It's documented
[here](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_RefreshPreferences.html)
as:

> The amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group (rounded up to the nearest integer). The default is 90.

Given the "rounded up to the nearest integer" bit, I'm not hopeful
that this will fix things for us, but we should try it anyway.