### PR TITLE
Revert "refactor refresh-instances"

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -167,34 +167,33 @@ jobs:
     passed: [deploy]
     trigger: true
   - in_parallel:
-    - do:
-      - task: refresh-web-node-asg
-        file: tech-ops/reliability-engineering/pipelines/tasks/asg-refresh-instances.yml
-        output_mapping:
-          refresh: web-refresh
-        params:
-          ASG_NAME: ((deployment_name))-concourse-web
-      - task: wait-for-web-node-asg
-        attempts: 10
-        file: tech-ops/reliability-engineering/pipelines/tasks/asg-wait-for-refresh.yml
-        input_mapping:
-          refresh: web-refresh
-        params:
-          ASG_NAME: ((deployment_name))-concourse-web
-    - do:
-      - task: refresh-main-team-workers-asg
-        file: tech-ops/reliability-engineering/pipelines/tasks/asg-refresh-instances.yml
-        output_mapping:
-          refresh: main-team-worker-refresh
-        params:
-          ASG_NAME: ((deployment_name))-main-concourse-worker
-      - task: wait-for-main-team-workers-asg
-        attempts: 10
-        file: tech-ops/reliability-engineering/pipelines/tasks/asg-wait-for-refresh.yml
-        input_mapping:
-          refresh: main-team-worker-refresh
-        params:
-          ASG_NAME: ((deployment_name))-main-concourse-worker
+    - task: refresh-web-node-asg
+      file: tech-ops/reliability-engineering/pipelines/tasks/asg-refresh-instances.yml
+      output_mapping:
+        refresh: web-refresh
+      params:
+        ASG_NAME: ((deployment_name))-concourse-web
+    - task: refresh-main-team-workers-asg
+      file: tech-ops/reliability-engineering/pipelines/tasks/asg-refresh-instances.yml
+      output_mapping:
+        refresh: main-team-worker-refresh
+      params:
+        ASG_NAME: ((deployment_name))-main-concourse-worker
+  - in_parallel:
+    - task: wait-for-web-node-asg
+      attempts: 10
+      file: tech-ops/reliability-engineering/pipelines/tasks/asg-wait-for-refresh.yml
+      input_mapping:
+        refresh: web-refresh
+      params:
+        ASG_NAME: ((deployment_name))-concourse-web
+    - task: wait-for-main-team-workers-asg
+      attempts: 10
+      file: tech-ops/reliability-engineering/pipelines/tasks/asg-wait-for-refresh.yml
+      input_mapping:
+        refresh: main-team-worker-refresh
+      params:
+        ASG_NAME: ((deployment_name))-main-concourse-worker
 
 - name: configure-teams
   serial: true


### PR DESCRIPTION
This reverts commit 1b265d9fa0c9cef8b9c938e0780f891bc91710c3.

I don't understand exactly how `do` works but it was doing weird
things where the second step started an instance refresh which caused
the first step to restart which I didn't think was possible...  this
reverts to how it was before where we start refreshing both ASGs, then
we wait for both ASGs in parallel.