### PR TITLE
Permit teams to Instance Refresh their own workers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": null,
+    "files": "go.sum",
     "lines": null
   },
-  "generated_at": "2020-11-12T09:18:49Z",
+  "generated_at": "2020-11-13T17:20:35Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -58,7 +58,84 @@
     }
   ],
   "results": {
-    "tasks/concourse-provider-config.yml": [
+    "ci/tasks/self-updating-pipeline.yaml": [
+      {
+        "hashed_secret": "1d4bfd13efde0cce38af417b2c8fdb36776f179f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Secret Keyword"
+      }
+    ],
+    "cyber-security/components/csls-splunk-broker/cmd/adapter/README.md": [
+      {
+        "hashed_secret": "77bd33f751b6c82a6cb040fe5076580090a1c8a4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword"
+      }
+    ],
+    "cyber-security/components/csls-splunk-broker/cmd/adapter/main_test.go": [
+      {
+        "hashed_secret": "dc3a469b5ceb1011c7a8e05940857c16034eb99e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Secret Keyword"
+      }
+    ],
+    "cyber-security/components/csls-splunk-broker/cmd/broker/README.md": [
+      {
+        "hashed_secret": "d3e436bb92839a365a98d1f6b88eb92c2175a2cc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "ba38d9788e794a8372032cdfe67c0c3b90ddea94",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Secret Keyword"
+      }
+    ],
+    "cyber-security/components/csls-splunk-broker/cmd/broker/main_test.go": [
+      {
+        "hashed_secret": "b51c7f08da79d9bebc8a6e6b7db38de24c54a6ca",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "1df2f5216b1d58007d44be7ec90dc5500a91d2fc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 40,
+        "type": "Secret Keyword"
+      }
+    ],
+    "cyber-security/components/csls-splunk-broker/pkg/csls/handler_test.go": [
+      {
+        "hashed_secret": "8b10d269af00868dc871ad51d7a7ceaa497c2dbe",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 37,
+        "type": "Secret Keyword"
+      }
+    ],
+    "cyber-security/components/splunk-query/test_search.py": [
+      {
+        "hashed_secret": "9a30414b851701ffdb127a3e83eb714185e77b8e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Secret Keyword"
+      }
+    ],
+    "reliability-engineering/pipelines/tasks/concourse-provider-config.yml": [
       {
         "hashed_secret": "d3df8a3b08a9de43b73eca1302d50e7a0e5b360f",
         "is_secret": false,
@@ -67,12 +144,21 @@
         "type": "Secret Keyword"
       }
     ],
-    "tasks/generate-deploy-info-pipelines-pipeline.yml": [
+    "reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml": [
       {
         "hashed_secret": "7f5152f39f9c6438ae1179e6ab49d7b27d3d7f24",
         "is_secret": false,
         "is_verified": false,
         "line_number": 36,
+        "type": "Secret Keyword"
+      }
+    ],
+    "reliability-engineering/terraform/modules/concourse-web/files/web-init.sh": [
+      {
+        "hashed_secret": "ef75b4c448783526eb2067ab38958f7fb4d6b963",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 42,
         "type": "Secret Keyword"
       }
     ]

--- a/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
+++ b/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
@@ -52,7 +52,11 @@ run:
             "in_parallel": [.[] | {
               "set_pipeline": "info",
               "team": .name,
-              "file": "tech-ops-private/reliability-engineering/terraform/deployments/gds-tech-ops/cd/pipelines/info.yml"
+              "file": "tech-ops-private/reliability-engineering/terraform/deployments/gds-tech-ops/cd/pipelines/info.yml",
+              "vars": {
+                "deployment": "${DEPLOYMENT_NAME}",
+                "team": .name
+                }
             }]
           }
         ]

--- a/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/iam.tf
@@ -156,9 +156,34 @@ resource "aws_iam_policy" "concourse_worker_base" {
 POLICY
 }
 
+resource "aws_iam_policy" "concourse_worker_self_refresh" {
+  name   = "${var.deployment}-${var.name}-concourse-worker-self-refresh"
+  policy = <<-POLICY
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "autoscaling:StartInstanceRefresh",
+          "autoscaling:DescribeInstanceRefreshes",
+          "autoscaling:CancelInstanceRefresh"
+        ],
+        "Resource": "${aws_autoscaling_group.concourse_worker.arn}"
+      }
+    ]
+  }
+POLICY
+}
+
 resource "aws_iam_role_policy_attachment" "concourse_worker_concourse_worker_base" {
   role       = var.worker_iam_role_name
   policy_arn = aws_iam_policy.concourse_worker_base.arn
+}
+
+resource "aws_iam_role_policy_attachment" "concourse_worker_concourse_worker_self_refresh" {
+  role       = var.worker_iam_role_name
+  policy_arn = aws_iam_policy.concourse_worker_self_refresh.arn
 }
 
 resource "aws_iam_role_policy_attachment" "concourse_worker_additional" {


### PR DESCRIPTION
This sets things up so that concourse worker roles are permitted to
start an Instance Refresh of themselves.

This will cause red/orange builds but if the workers are stuck anyway
it might be useful?  (on the other hand, if the workers are stuck
maybe this won't help...)