### PR TITLE
Update cloudwatch event pattern

### DIFF
--- a/cyber-security/modules/csls_s3_object_logging/README.md
+++ b/cyber-security/modules/csls_s3_object_logging/README.md
@@ -13,11 +13,11 @@ module "s3_object_logging_test" {
   source                     = "git::https://github.com/alphagov/tech-ops.git//cyber-security/modules/csls_s3_object_logging?ref=8743cc8372b896a694174d5354b6cbdd6c574005"
   cloudwatch_destination_arn = "[ ask in #cyber-security-help ]"
   logging_suffix             = ""
-  bucket_arn_list = [
-    "arn:aws:s3:::my-1st-bucket/",
-    "arn:aws:s3:::my-2nd-bucket/"
+  bucket_names_list          = [
+    "my-1st-bucket",
+    "my-2nd-bucket"
   ]
-  tags = {
+  tags =
     Add         = "your own"
     Tags        = "to tag all the"
     Created     = "resources"
@@ -26,15 +26,13 @@ module "s3_object_logging_test" {
 
 ```  
 
-NOTE: If individual bucket ARNS are added they must be appended with a trailing slash.
-
 ### Module Variables
 
 * `cloudwatch_destination_arn` (Required):  
     Ask in [#cyber-security-help](https://gds.slack.com/archives/CCMPJKFDK)
 * `cloudwatch_filter_pattern` (Optional): 
     Filter events before sending to Splunk.
-* `bucket_arn_list` (Optional):  
+* `bucket_names_list` (Optional):  
     The default behaviour is to monitor all buckets in the account. 
 * `logging_suffix` (Optional): 
     The default behaviour is to label things with the account ID.

--- a/cyber-security/modules/csls_s3_object_logging/cloudtrail.tf
+++ b/cyber-security/modules/csls_s3_object_logging/cloudtrail.tf
@@ -11,7 +11,7 @@ resource "aws_cloudtrail" "s3_object_logging_trail" {
 
     data_resource {
       type   = "AWS::S3::Object"
-      values = [join("", ["arn:aws:s3:::", var.bucket_arn, "/"])]
+      values = formatlist("arn:aws:s3:::%s/", var.bucket_arns)
     }
   }
 }

--- a/cyber-security/modules/csls_s3_object_logging/cloudtrail.tf
+++ b/cyber-security/modules/csls_s3_object_logging/cloudtrail.tf
@@ -11,7 +11,7 @@ resource "aws_cloudtrail" "s3_object_logging_trail" {
 
     data_resource {
       type   = "AWS::S3::Object"
-      values = var.bucket_arn_list
+      values = [join("", ["arn:aws:s3:::", var.bucket_arn, "/"])]
     }
   }
 }

--- a/cyber-security/modules/csls_s3_object_logging/cloudtrail.tf
+++ b/cyber-security/modules/csls_s3_object_logging/cloudtrail.tf
@@ -11,7 +11,7 @@ resource "aws_cloudtrail" "s3_object_logging_trail" {
 
     data_resource {
       type   = "AWS::S3::Object"
-      values = formatlist("arn:aws:s3:::%s/", var.bucket_arns)
+      values = formatlist("arn:aws:s3:::%s/", var.bucket_names_list)
     }
   }
 }

--- a/cyber-security/modules/csls_s3_object_logging/cloudwatch.tf
+++ b/cyber-security/modules/csls_s3_object_logging/cloudwatch.tf
@@ -5,7 +5,7 @@ resource "aws_cloudwatch_event_rule" "s3_events" {
   tags = merge(local.tags, map("Name", local.cloudwatch_event_rule_name))
   
   event_pattern = templatefile("${path.module}/json/cloudwatch_event_pattern.json.tpl", {
-    bucket_arn = var.bucket_arn
+    bucket_arn = jsonencode(var.bucket_arn)
   })
 }
 

--- a/cyber-security/modules/csls_s3_object_logging/cloudwatch.tf
+++ b/cyber-security/modules/csls_s3_object_logging/cloudwatch.tf
@@ -5,7 +5,7 @@ resource "aws_cloudwatch_event_rule" "s3_events" {
   tags = merge(local.tags, map("Name", local.cloudwatch_event_rule_name))
   
   event_pattern = templatefile("${path.module}/json/cloudwatch_event_pattern.json.tpl", {
-    bucket_arn = jsonencode(var.bucket_arn)
+    bucket_arns = jsonencode(var.bucket_arns)
   })
 }
 

--- a/cyber-security/modules/csls_s3_object_logging/cloudwatch.tf
+++ b/cyber-security/modules/csls_s3_object_logging/cloudwatch.tf
@@ -5,7 +5,7 @@ resource "aws_cloudwatch_event_rule" "s3_events" {
   tags = merge(local.tags, map("Name", local.cloudwatch_event_rule_name))
   
   event_pattern = templatefile("${path.module}/json/cloudwatch_event_pattern.json.tpl", {
-    bucket_arns = jsonencode(var.bucket_arns)
+    bucket_names_list = jsonencode(var.bucket_names_list)
   })
 }
 

--- a/cyber-security/modules/csls_s3_object_logging/cloudwatch.tf
+++ b/cyber-security/modules/csls_s3_object_logging/cloudwatch.tf
@@ -5,7 +5,7 @@ resource "aws_cloudwatch_event_rule" "s3_events" {
   tags = merge(local.tags, map("Name", local.cloudwatch_event_rule_name))
   
   event_pattern = templatefile("${path.module}/json/cloudwatch_event_pattern.json.tpl", {
-    resources = jsonencode(var.bucket_arn_list)
+    bucket_arn = var.bucket_arn
   })
 }
 

--- a/cyber-security/modules/csls_s3_object_logging/json/cloudwatch_event_pattern.json.tpl
+++ b/cyber-security/modules/csls_s3_object_logging/json/cloudwatch_event_pattern.json.tpl
@@ -35,7 +35,7 @@
       "GetObjectLockLegalHold"
     ],
     "requestParameters": {
-      "bucketName": ${bucket_arns}
+      "bucketName": ${bucket_names_list}
     }
   }
 }

--- a/cyber-security/modules/csls_s3_object_logging/json/cloudwatch_event_pattern.json.tpl
+++ b/cyber-security/modules/csls_s3_object_logging/json/cloudwatch_event_pattern.json.tpl
@@ -35,7 +35,7 @@
       "GetObjectLockLegalHold"
     ],
     "requestParameters": {
-      "bucketName": ${bucket_arn}
+      "bucketName": ${bucket_arns}
     }
   }
 }

--- a/cyber-security/modules/csls_s3_object_logging/json/cloudwatch_event_pattern.json.tpl
+++ b/cyber-security/modules/csls_s3_object_logging/json/cloudwatch_event_pattern.json.tpl
@@ -33,7 +33,9 @@
       "PutObjectLockLegalHold",
       "GetObjectLockRetention",
       "GetObjectLockLegalHold"
-    ]
-  },
-  "resources": ${resources}
+    ],
+    "requestParameters": {
+      "bucketName": ${bucket_arn}
+    }
+  }
 }

--- a/cyber-security/modules/csls_s3_object_logging/locals.tf
+++ b/cyber-security/modules/csls_s3_object_logging/locals.tf
@@ -1,7 +1,7 @@
 # This allows you to customise the naming of the components for 2 scenarios:
-# 1. logging_suffix = [default], bucket_arn_list = [default]
+# 1. logging_suffix = [default], bucket_names_list = [default]
 #     logs all buckets in account under a generic name
-# 2. logging_suffix = specified, bucket_arn_list = specified bucket ARNs.
+# 2. logging_suffix = specified, bucket_names_list = specified bucket ARNs.
 #     logs specified buckets under a specific name
 #     this is for logging a group of buckets that belong to the same service
 #     or for logging a single bucket

--- a/cyber-security/modules/csls_s3_object_logging/vars.tf
+++ b/cyber-security/modules/csls_s3_object_logging/vars.tf
@@ -9,10 +9,10 @@ variable "cloudwatch_filter_pattern" {
   default     = ""
 }
 
-variable "bucket_arns" {
+variable "bucket_names_list" {
   type        = list(string)
-  description = "Individual bucket ARNs should be appended with a trailing /. By default log all S3 buckets in the account."
-  default = ["arn:aws:s3:::"]
+  description = "A list of bucket names that you want to log."
+  default     = [""]
 }
 
 variable "logging_suffix" {

--- a/cyber-security/modules/csls_s3_object_logging/vars.tf
+++ b/cyber-security/modules/csls_s3_object_logging/vars.tf
@@ -12,7 +12,7 @@ variable "cloudwatch_filter_pattern" {
 variable "bucket_names_list" {
   type        = list(string)
   description = "A list of bucket names that you want to log."
-  default     = [""]
+  default     = []
 }
 
 variable "logging_suffix" {

--- a/cyber-security/modules/csls_s3_object_logging/vars.tf
+++ b/cyber-security/modules/csls_s3_object_logging/vars.tf
@@ -9,12 +9,11 @@ variable "cloudwatch_filter_pattern" {
   default     = ""
 }
 
-variable "bucket_arn_list" {
-  type        = list(string)
+variable "bucket_arn" {
+  # type        = list(string)
+  type          = string
   description = "Individual bucket ARNs should be appended with a trailing /. By default log all S3 buckets in the account."
-  default = [
-    "arn:aws:s3:::"
-  ]
+  default = "arn:aws:s3:::"
 }
 
 variable "logging_suffix" {

--- a/cyber-security/modules/csls_s3_object_logging/vars.tf
+++ b/cyber-security/modules/csls_s3_object_logging/vars.tf
@@ -9,11 +9,10 @@ variable "cloudwatch_filter_pattern" {
   default     = ""
 }
 
-variable "bucket_arn" {
-  # type        = list(string)
-  type          = string
+variable "bucket_arns" {
+  type        = list(string)
   description = "Individual bucket ARNs should be appended with a trailing /. By default log all S3 buckets in the account."
-  default = "arn:aws:s3:::"
+  default = ["arn:aws:s3:::"]
 }
 
 variable "logging_suffix" {


### PR DESCRIPTION
It turns out that in order to listen to a particular s3 bucket, you don't add it as a resource to the cloudwatch event pattern, you add it as a request parameter to the pattern. This works with s3 buckets, but we'll have to think about how to genericise this further.

relates #126 