### PR TITLE
Avoid Prometheus issues when parsing resolv.conf

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
@@ -9,6 +9,11 @@ apt-get upgrade --yes
 export AWS_REGION=eu-west-2
 export AWS_DEFAULT_REGION=eu-west-2
 
+# Guard against Prometheus crashing because of a /etc/resolv.conf
+# parsing issue https://github.com/miekg/dns/pull/642
+rm /etc/resolv.conf
+sed -e 's/ trust-ad//' < /run/systemd/resolve/stub-resolv.conf > /etc/resolv.conf
+
 echo 'Configuring prometheus EBS'
 vol=""
 while [ -z "$vol" ]; do


### PR DESCRIPTION
This uses the same approach as taken for the Observe Prometheus [1].

The issue has been fixed in the upstream library [2] and the fix was
released in version 1.0.5, but the current Ubuntu package is built
with 1.0.4.

1: https://github.com/alphagov/prometheus-aws-configuration-beta/pull/440
2: https://github.com/miekg/dns/pull/642