### PR TITLE
Don't rely on governmentpaas/awscli to build octodns container

### DIFF
--- a/reliability-engineering/dockerfiles/govsvc/octodns/Dockerfile
+++ b/reliability-engineering/dockerfiles/govsvc/octodns/Dockerfile
@@ -1,3 +1,7 @@
-FROM governmentpaas/awscli
-RUN apk add --update py3-pip && \
-    pip3 install octodns boto3
+FROM ghcr.io/alphagov/paas/curl-ssl
+
+ENV AWSCLI_VERSION "1.18.140"
+ENV PACKAGES "groff less python3 py-pip jq"
+
+RUN apk add --update --no-cache $PACKAGES \
+    && pip3 install awscli==$AWSCLI_VERSION octodns boto3


### PR DESCRIPTION
Since https://github.com/boto/boto3/issues/2596, we can't just pip3 install
boto3 on top of it. The image we use comes from this PaaS repository:
https://github.com/alphagov/paas-docker-cloudfoundry-tools/blob/main/awscli/Dockerfile
which pins awscli to 1.17.2. This commit uses 1.18.140 which shouldn't have the issue.

Also, use curl-ssl from GHCR instead of DockerHub.