### PR TITLE
concourse-web: add db_apply_immediately variable

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/rds.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/rds.tf
@@ -33,6 +33,7 @@ resource "aws_db_instance" "concourse" {
   deletion_protection          = true
   multi_az                     = var.db_multi_az
   backup_retention_period      = var.db_backup_retention_period
+  apply_immediately            = var.db_apply_immediately
 
   tags = {
     Name       = "${var.deployment}-concourse"

--- a/reliability-engineering/terraform/modules/concourse-web/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/variables.tf
@@ -115,6 +115,10 @@ variable "db_storage_iops" {
   default = null
 }
 
+variable "db_apply_immediately" {
+  default = false
+}
+
 variable "concourse_version" {
   type = string
 }


### PR DESCRIPTION
https://trello.com/c/9eMER1Re

Consensus seems to be that we apply concourse db changes in-hours rather than wait for a maintenance window, so we'll need this to control it.