### PR TITLE
concourse-web: add options for specifying rds db's storage parameters

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/rds.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/rds.tf
@@ -20,7 +20,8 @@ resource "aws_db_instance" "concourse" {
   password                     = random_string.concourse_db_password.result
   db_subnet_group_name         = aws_db_subnet_group.concourse.name
   allocated_storage            = var.db_storage_gb
-  storage_type                 = "gp2"
+  storage_type                 = var.db_storage_type
+  iops                         = var.db_storage_iops
   engine                       = "postgres"
   engine_version               = "10"
   instance_class               = var.db_instance_type

--- a/reliability-engineering/terraform/modules/concourse-web/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/variables.tf
@@ -107,6 +107,14 @@ variable "db_backup_retention_period" {
   default = 0
 }
 
+variable "db_storage_type" {
+  default = "gp2"
+}
+
+variable "db_storage_iops" {
+  default = null
+}
+
 variable "concourse_version" {
   type = string
 }


### PR DESCRIPTION
https://trello.com/c/9eMER1Re

These are both things we are likely to make use of in the upgrade of big concourse's postgres to multi-az. In similar vein to https://github.com/alphagov/tech-ops/pull/218