### PR TITLE
build-re-request-an-aws-account pipeline job: use ruby 2.7.2

### DIFF
--- a/reliability-engineering/pipelines/internal-apps.yml
+++ b/reliability-engineering/pipelines/internal-apps.yml
@@ -166,7 +166,7 @@ jobs:
             type: docker-image
             source:
               repository: ruby
-              tag: 2.7.1
+              tag: 2.7.2
           inputs:
             - name: re-request-an-aws-account-git
               path: repo


### PR DESCRIPTION
Because the version of ruby the app specifically mandates and the version it's provided with are defined separately in separate repositories.

Needed to let https://github.com/alphagov/re-request-an-aws-account/pull/117 be successfully released.