### PR TITLE
Revert "build-re-request-an-aws-account pipeline job: use ruby 2.7.2"

### DIFF
--- a/reliability-engineering/pipelines/internal-apps.yml
+++ b/reliability-engineering/pipelines/internal-apps.yml
@@ -166,7 +166,7 @@ jobs:
             type: docker-image
             source:
               repository: ruby
-              tag: 2.7.2
+              tag: 2.7.1
           inputs:
             - name: re-request-an-aws-account-git
               path: repo


### PR DESCRIPTION
Reverts alphagov/tech-ops#221

PaaS' default ruby buildpack isn't ready for 2.7.2 yet.