### PR TITLE
Replace count with for_each and amend key references accordingly

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-keys/local-users.tf
+++ b/reliability-engineering/terraform/modules/concourse-keys/local-users.tf
@@ -1,17 +1,17 @@
 resource "random_string" "local_user_password" {
-  count = length(var.worker_team_names)
+  for_each = toset(var.worker_team_names)
 
   special = false
   length  = 32
 }
 
 resource "aws_ssm_parameter" "concourse_local_usernames_and_passwords" {
-  count = length(var.worker_team_names)
+  for_each = toset(var.worker_team_names)
 
-  name        = "/${var.deployment}/concourse/pipelines/${element(var.worker_team_names, count.index)}/readonly_local_user_password"
+  name        = "/${var.deployment}/concourse/pipelines/${each.key}/readonly_local_user_password"
   type        = "SecureString"
-  description = "Password for the local user with admin access to team ${element(var.worker_team_names, count.index)}"
-  value       = random_string.local_user_password[count.index].result
+  description = "Password for the local user with admin access to team ${each.key}"
+  value       = random_string.local_user_password[each.key].result
   key_id      = aws_kms_key.concourse_worker_shared.key_id
 
   tags = {

--- a/reliability-engineering/terraform/modules/concourse-keys/worker.tf
+++ b/reliability-engineering/terraform/modules/concourse-keys/worker.tf
@@ -1,5 +1,5 @@
 resource "tls_private_key" "concourse_worker_ssh_keys" {
-  count = length(var.worker_team_names)
+  for_each = toset(var.worker_team_names)
 
   algorithm = "RSA"
   rsa_bits  = 4096
@@ -26,9 +26,9 @@ output "concourse_worker_ssh_private_keys_pem" {
 }
 
 resource "aws_iam_role" "concourse_workers" {
-  count = length(var.worker_team_names)
+  for_each = toset(var.worker_team_names)
 
-  name = "${var.deployment}-${var.worker_team_names[count.index]}-concourse-worker"
+  name = "${var.deployment}-${each.key}-concourse-worker"
 
   assume_role_policy = <<-ARP
   {


### PR DESCRIPTION
Changes the way terraform iterates through team names to avoid it building things from scratch when new teams are added.