### PR TITLE
concourse-monitoring: grafana dashboard additions

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse-internal.json
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse-internal.json
@@ -56,7 +56,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "sum(increase(concourse_builds_duration_seconds_bucket { exported_job=~\"$exported_job\", pipeline=~\"$pipeline\"}[5m])) by (le)",
+          "expr": "sum(increase(concourse_builds_duration_seconds_bucket { exported_job=~\"$exported_job\", pipeline=~\"$pipeline\", team=~\"$team\" }[5m])) by (le)",
           "format": "heatmap",
           "instant": false,
           "interval": "5m",
@@ -488,9 +488,35 @@
         "includeAll": true,
         "label": "",
         "multi": false,
-        "name": "pipeline",
+        "name": "team",
         "options": [],
         "query": "concourse_builds_duration_seconds_bucket",
+        "refresh": 2,
+        "regex": ".*team=\\\"([^\"]+)\\\".*",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": "",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "Prometheus 1",
+        "definition": "concourse_builds_duration_seconds_bucket { team=~\"$team\" }",
+        "hide": 0,
+        "includeAll": true,
+        "label": "",
+        "multi": false,
+        "name": "pipeline",
+        "options": [],
+        "query": "concourse_builds_duration_seconds_bucket { team=~\"$team\" }",
         "refresh": 2,
         "regex": ".*pipeline=\\\"([^\"]+)\\\".*",
         "skipUrlSync": false,
@@ -504,19 +530,19 @@
       {
         "allValue": "",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
         "datasource": "Prometheus 1",
-        "definition": "concourse_builds_duration_seconds_bucket { pipeline=~\"$pipeline\" }",
+        "definition": "concourse_builds_duration_seconds_bucket { pipeline=~\"$pipeline\", team=~\"$team\" }",
         "hide": 0,
         "includeAll": true,
         "label": "",
         "multi": false,
         "name": "exported_job",
         "options": [],
-        "query": "concourse_builds_duration_seconds_bucket { pipeline=~\"$pipeline\" }",
+        "query": "concourse_builds_duration_seconds_bucket { pipeline=~\"$pipeline\", team=~\"$team\" }",
         "refresh": 2,
         "regex": ".*exported_job=\\\"([^\"]+)\\\".*",
         "skipUrlSync": false,
@@ -548,6 +574,6 @@
   },
   "timezone": "",
   "title": "Concourse internal",
-  "uid": "conc-int",
-  "version": 0
+  "uid": "JgCeuzcMk",
+  "version": 3
 }

--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse.json
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/dashboards/concourse.json
@@ -3105,6 +3105,104 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "The number of \"up\" workers per team according to prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 8,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 31
+      },
+      "hiddenSeries": false,
+      "id": 62,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (team)(up{role=\"concourse-worker\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{team}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "No. of \"Up\" Workers / Team",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": false,
@@ -3151,5 +3249,5 @@
   "timezone": "browser",
   "title": "Concourse",
   "uid": "bpMdZazMk",
-  "version": 3
+  "version": 6
 }


### PR DESCRIPTION
https://trello.com/c/wYDmNP01

These allow us to:

 - see the number of "up" workers per team according to prometheus
 - drill down into per-team build completion info

Both pretty useful, especially during an incident.