### PR TITLE
Give the rest of the team pipeline-operator permissions in the `main` team

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/launch-template.tf
@@ -14,15 +14,16 @@ data "template_file" "concourse_web_cloud_init" {
   template = file("${path.module}/files/web-init.sh")
 
   vars = {
-    deployment                          = var.deployment
-    main_team_github_team               = var.main_team_github_team
-    concourse_external_url              = aws_route53_record.concourse_public_deployment.fqdn
-    concourse_db_url                    = aws_route53_record.concourse_private_db.fqdn
-    concourse_version                   = var.concourse_version
-    concourse_sha1                      = var.concourse_sha1
-    concourse_web_bucket                = aws_s3_bucket.concourse_web.bucket
-    worker_keys_s3_object_key           = aws_s3_bucket_object.concourse_web_team_authorized_worker_keys.id
-    concourse_web_syslog_log_group_name = local.concourse_web_syslog_log_group_name
+    deployment                              = var.deployment
+    main_team_github_team                   = var.main_team_github_team
+    main_team_pipeline_operator_github_team = var.main_team_pipeline_operator_github_team
+    concourse_external_url                  = aws_route53_record.concourse_public_deployment.fqdn
+    concourse_db_url                        = aws_route53_record.concourse_private_db.fqdn
+    concourse_version                       = var.concourse_version
+    concourse_sha1                          = var.concourse_sha1
+    concourse_web_bucket                    = aws_s3_bucket.concourse_web.bucket
+    worker_keys_s3_object_key               = aws_s3_bucket_object.concourse_web_team_authorized_worker_keys.id
+    concourse_web_syslog_log_group_name     = local.concourse_web_syslog_log_group_name
   }
 }
 

--- a/reliability-engineering/terraform/modules/concourse-web/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/variables.tf
@@ -31,6 +31,11 @@ variable "main_team_github_team" {
   type        = string
 }
 
+variable "main_team_pipeline_operator_github_team" {
+  description = "GitHub team given pipeline-operator in the main team, $org:$teamName"
+  type        = string
+}
+
 variable "worker_team_names" {
   description = "The names of concourse worker team names, i.e. hosts, for keygen."
   type        = list(string)


### PR DESCRIPTION
Without scary main team member/owner permissions.