### PR TITLE
Create automate/task-toolbox docker image

### DIFF
--- a/reliability-engineering/dockerfiles/govsvc/concourse-task-toolbox/Dockerfile
+++ b/reliability-engineering/dockerfiles/govsvc/concourse-task-toolbox/Dockerfile
@@ -1,0 +1,30 @@
+FROM hashicorp/terraform:0.12.29 AS task-toolbox
+
+RUN apk add --update \
+	curl \
+	git \
+	wget \
+	unzip \
+	jq \
+	openssh \
+	ruby \
+	bash \
+	openssl \
+	file \
+	tar \
+	netcat-openbsd \
+	groff \
+	less \
+	python3 \
+	py3-pip \
+	mailcap \
+	ncurses \
+	gnupg \
+	rpm \
+	&& pip3 install awscli s3cmd yq PyYAML \
+	&& rm /var/cache/apk/*
+
+COPY bin/aws-assume-role /usr/local/bin/
+
+ENTRYPOINT ["/bin/bash"]
+CMD []

--- a/reliability-engineering/dockerfiles/govsvc/concourse-task-toolbox/bin/aws-assume-role
+++ b/reliability-engineering/dockerfiles/govsvc/concourse-task-toolbox/bin/aws-assume-role
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+
+unset AWS_SESSION_TOKEN
+
+role_arn="$1"
+temp_role=$(aws sts assume-role \
+                    --role-arn "${role_arn}" \
+                    --role-session-name "concourse-task")
+
+echo export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+echo export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+echo export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)

--- a/reliability-engineering/pipelines/build-govsvc-docker.yml
+++ b/reliability-engineering/pipelines/build-govsvc-docker.yml
@@ -102,6 +102,12 @@ resources:
   source:
     repository: hashicorp/terraform
 
+- name: terraform-0.12
+  type: docker-image
+  source:
+    repository: hashicorp/terraform
+    tag: 0.12.29
+
 - name: govsvc-aws-terraform
   type: docker-image
   source:
@@ -123,6 +129,21 @@ resources:
     branch: master
     paths:
     - reliability-engineering/dockerfiles/govsvc/aws-terraform
+
+- name: github-automate-task-toolbox
+  type: docker-image
+  source:
+    username: ((github-packages-username))
+    password: ((github-packages-token))
+    repository: ghcr.io/alphagov/automate/task-toolbox
+
+- name: automate-task-toolbox-git
+  type: git
+  source:
+    uri: https://github.com/alphagov/tech-ops.git
+    branch: master
+    paths:
+    - reliability-engineering/dockerfiles/govsvc/concourse-task-toolbox
 
 jobs:
 - name: selfupdate
@@ -234,4 +255,19 @@ jobs:
     get_params: {skip_download: true}
   - put: github-awsc
     params: *awsc-params
+    get_params: {skip_download: true}
+
+- name: build-github-automate-task-toolbox
+  serial: true
+  plan:
+  - in_parallel:
+    - get: automate-task-toolbox-git
+      trigger: true
+    - get: terraform-0.12
+      trigger: true
+      params: {save: true}
+  - put: github-automate-task-toolbox
+    params:
+      build: automate-task-toolbox-git/reliability-engineering/dockerfiles/govsvc/concourse-task-toolbox
+      load_bases: [ terraform-0.12 ]
     get_params: {skip_download: true}


### PR DESCRIPTION
This is effectively a fork of GSP's concourse-task-toolbox that can continue
to be used in Verify and Big Concourse. It doesn't have things like kubectl.
It is only pushed to GHCR, since we wouldn't want to replace the GSP
task-toolbox as some stuff still uses it, and our docker registry of choice is
now GHCR rather than DockerHub.