### PR TITLE
Add gds-ips module to tech-ops-private resource

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -26,6 +26,7 @@ resources:
     private_key: ((re-autom8-ci-github-ssh-private-key))
     paths:
       - reliability-engineering/terraform/deployments/gds-tech-ops/((deployment_name))
+      - reliability-engineering/terraform/modules/gds-ips
 - name: tech-ops
   icon: github
   type: git


### PR DESCRIPTION
This is a module that gets included from other terraform in tech-ops-private.