### PR TITLE
Set autoscaling groups min size for workers from 0 to the desired size,

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/autoscaling-group.tf
@@ -1,7 +1,7 @@
 resource "aws_autoscaling_group" "concourse_worker" {
   name                = "${var.deployment}-${var.name}-concourse-worker"
   max_size            = var.desired_capacity * 2
-  min_size            = 0
+  min_size            = var.desired_capacity
   desired_capacity    = var.desired_capacity
   vpc_zone_identifier = var.subnet_ids
 


### PR DESCRIPTION
this should stop instances where we get autoscaling roups with 0
workers. And also more succinctly gives a reference to what the minimum desired
size of a ASG should be.