### PR TITLE
Add concourse secrets admin module

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-base/openid.tf
+++ b/reliability-engineering/terraform/modules/concourse-base/openid.tf
@@ -1,0 +1,13 @@
+resource "aws_iam_openid_connect_provider" "concourse_secrets_admin" {
+  url = var.openid_connect_provider_url
+
+  client_id_list = [
+    var.openid_connect_provider_client_id,
+  ]
+
+  thumbprint_list = var.openid_connect_provider_tls_cert_thumbprints
+}
+
+output "aws_iam_openid_connect_provider_arn" {
+  value = aws_iam_openid_connect_provider.concourse_secrets_admin.arn
+}

--- a/reliability-engineering/terraform/modules/concourse-base/openid.tf
+++ b/reliability-engineering/terraform/modules/concourse-base/openid.tf
@@ -1,4 +1,10 @@
 resource "aws_iam_openid_connect_provider" "concourse_secrets_admin" {
+  for_each = (
+    trimspace(var.openid_connect_provider_url) != "" ||
+    trimspace(var.openid_connect_provider_client_id) != "" ||
+    length(var.openid_connect_provider_tls_cert_thumbprints) != 0
+  ) ? toset(["main"]) : toset([])
+
   url = var.openid_connect_provider_url
 
   client_id_list = [
@@ -9,5 +15,5 @@ resource "aws_iam_openid_connect_provider" "concourse_secrets_admin" {
 }
 
 output "aws_iam_openid_connect_provider_arn" {
-  value = aws_iam_openid_connect_provider.concourse_secrets_admin.arn
+  value = contains(keys(aws_iam_openid_connect_provider.concourse_secrets_admin), "main") ? aws_iam_openid_connect_provider.concourse_secrets_admin["main"].arn : ""
 }

--- a/reliability-engineering/terraform/modules/concourse-base/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-base/variables.tf
@@ -14,6 +14,18 @@ variable "number_of_availability_zones" {
   default = 2
 }
 
+variable "openid_connect_provider_url" {
+  type = string
+}
+
+variable "openid_connect_provider_client_id" {
+    type = string
+}
+
+variable "openid_connect_provider_tls_cert_thumbprints" {
+  type = list(string)
+}
+
 data "aws_availability_zones" "available" {}
 
 locals {

--- a/reliability-engineering/terraform/modules/concourse-base/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-base/variables.tf
@@ -15,15 +15,16 @@ variable "number_of_availability_zones" {
 }
 
 variable "openid_connect_provider_url" {
-  type = string
+  default = ""
 }
 
 variable "openid_connect_provider_client_id" {
-    type = string
+  default = ""
 }
 
 variable "openid_connect_provider_tls_cert_thumbprints" {
   type = list(string)
+  default = []
 }
 
 data "aws_availability_zones" "available" {}

--- a/reliability-engineering/terraform/modules/concourse-secrets-admin/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-secrets-admin/iam.tf
@@ -1,0 +1,77 @@
+resource "aws_iam_role" "concourse_secrets_admin" {
+  name = "${var.deployment}-${var.concourse_team_name}-concourse-secrets-admin"
+
+  assume_role_policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "Federated": "${module.concourse_base.aws_iam_openid_connect_provider_arn}"
+        },
+        "Action": "sts:AssumeRoleWithWebIdentity",
+        "Condition": {
+          "StringEquals": {
+            "${var.oidc_host_path}:aud": "${var.github_oauth_client_id}",
+            "aws:RequestTag/t${var.trusted_github_team_id}": "t"
+          }
+        }
+      },
+      {
+        "Sid": "AllowPassSessionTagsAndTransitive",
+        "Effect": "Allow",
+        "Action": "sts:TagSession",
+        "Principal": {
+          "Federated": "${module.concourse_base.aws_iam_openid_connect_provider_arn}"
+        }
+      }
+    ]
+  }
+EOF
+}
+
+resource "aws_iam_role_policy" "concourse_secrets_admin" {
+  name = "${var.deployment}-${var.concourse_team_name}-concourse-secrets-admin-policy"
+  role = aws_iam_role.concourse_secrets_admin.id
+
+  policy = <<-POLICY
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "ssm:GetParameter",
+          "ssm:GetParameterHistory",
+          "ssm:GetParameters",
+          "ssm:GetParametersByPath",
+          "ssm:DeleteParameter",
+          "ssm:PutParameter"
+        ],
+        "Effect": "Allow",
+        "Resource": [
+          "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/concourse/pipelines/${var.concourse_team_name}/*"
+        ]
+      }, {
+        "Action": [
+          "ssm:DeleteParameter",
+          "ssm:PutParameter"
+        ],
+        "Effect": "Deny",
+        "Resource": [
+          "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/concourse/pipelines/${var.concourse_team_name}/readonly_*"
+        ]
+      }, {
+        "Effect": "Allow",
+        "Action": [
+          "kms:ListKeys",
+          "kms:ListAliases",
+          "kms:Describe*",
+          "kms:Decrypt"
+        ],
+        "Resource": "${var.kms_key_arn}"
+      }
+    ]
+  }
+POLICY
+}

--- a/reliability-engineering/terraform/modules/concourse-secrets-admin/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-secrets-admin/iam.tf
@@ -1,77 +1,72 @@
 resource "aws_iam_role" "concourse_secrets_admin" {
   name = "${var.deployment}-${var.concourse_team_name}-concourse-secrets-admin"
 
-  assume_role_policy = <<-EOF
-  {
-    "Version": "2012-10-17",
-    "Statement": [
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
       {
-        "Effect": "Allow",
-        "Principal": {
-          "Federated": "${module.concourse_base.aws_iam_openid_connect_provider_arn}"
-        },
-        "Action": "sts:AssumeRoleWithWebIdentity",
-        "Condition": {
-          "StringEquals": {
-            "${var.oidc_host_path}:aud": "${var.github_oauth_client_id}",
-            "aws:RequestTag/t${var.trusted_github_team_id}": "t"
+        Effect = "Allow"
+        Principal = {
+          Federated = module.concourse_base.aws_iam_openid_connect_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${var.oidc_host_path}:aud" = var.github_oauth_client_id
+            "aws:RequestTag/t${var.trusted_github_team_id}" = "t"
           }
         }
-      },
-      {
-        "Sid": "AllowPassSessionTagsAndTransitive",
-        "Effect": "Allow",
-        "Action": "sts:TagSession",
-        "Principal": {
-          "Federated": "${module.concourse_base.aws_iam_openid_connect_provider_arn}"
+      }, {
+        Sid = "AllowPassSessionTagsAndTransitive"
+        Effect = "Allow"
+        Action = "sts:TagSession"
+        Principal = {
+          Federated = module.concourse_base.aws_iam_openid_connect_provider_arn
         }
       }
     ]
   }
-EOF
 }
 
 resource "aws_iam_role_policy" "concourse_secrets_admin" {
   name = "${var.deployment}-${var.concourse_team_name}-concourse-secrets-admin-policy"
   role = aws_iam_role.concourse_secrets_admin.id
 
-  policy = <<-POLICY
-  {
-    "Version": "2012-10-17",
-    "Statement": [
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
       {
-        "Action": [
+        Action = [
           "ssm:GetParameter",
           "ssm:GetParameterHistory",
           "ssm:GetParameters",
           "ssm:GetParametersByPath",
           "ssm:DeleteParameter",
-          "ssm:PutParameter"
-        ],
-        "Effect": "Allow",
-        "Resource": [
+          "ssm:PutParameter",
+        ]
+        Effect = "Allow"
+        Resource = [
           "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/concourse/pipelines/${var.concourse_team_name}/*"
         ]
       }, {
-        "Action": [
+        Action = [
           "ssm:DeleteParameter",
-          "ssm:PutParameter"
-        ],
-        "Effect": "Deny",
-        "Resource": [
+          "ssm:PutParameter",
+        ]
+        Effect = "Deny"
+        Resource = [
           "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.account.account_id}:parameter/${var.deployment}/concourse/pipelines/${var.concourse_team_name}/readonly_*"
         ]
       }, {
-        "Effect": "Allow",
-        "Action": [
+        Action = [
           "kms:ListKeys",
           "kms:ListAliases",
           "kms:Describe*",
-          "kms:Decrypt"
-        ],
-        "Resource": "${var.kms_key_arn}"
+          "kms:Decrypt",
+        ]
+        Effect = "Allow"
+        Resource = var.kms_key_arn
       }
     ]
-  }
-POLICY
+  })
 }

--- a/reliability-engineering/terraform/modules/concourse-secrets-admin/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-secrets-admin/iam.tf
@@ -7,7 +7,7 @@ resource "aws_iam_role" "concourse_secrets_admin" {
       {
         Effect = "Allow"
         Principal = {
-          Federated = module.concourse_base.aws_iam_openid_connect_provider_arn
+          Federated = var.iam_oidc_provider_arn
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
@@ -21,7 +21,7 @@ resource "aws_iam_role" "concourse_secrets_admin" {
         Effect = "Allow"
         Action = "sts:TagSession"
         Principal = {
-          Federated = module.concourse_base.aws_iam_openid_connect_provider_arn
+          Federated = var.iam_oidc_provider_arn
         }
       }
     ]

--- a/reliability-engineering/terraform/modules/concourse-secrets-admin/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-secrets-admin/variables.tf
@@ -1,0 +1,25 @@
+data "aws_caller_identity" "account" {}
+
+variable "deployment" {
+  type = string
+}
+
+variable "concourse_team_name" {
+  type = string
+}
+
+variable "kms_key_arn" {
+  type = string
+}
+
+variable "oidc_host_path" {
+  type = string
+}
+
+variable "github_oauth_client_id" {
+  type = string
+}
+
+variable "trusted_github_team_id" {
+  type = string
+}

--- a/reliability-engineering/terraform/modules/concourse-secrets-admin/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-secrets-admin/variables.tf
@@ -16,6 +16,10 @@ variable "oidc_host_path" {
   type = string
 }
 
+variable "iam_oidc_provider_arn" {
+  type = string
+}
+
 variable "github_oauth_client_id" {
   type = string
 }


### PR DESCRIPTION
# Why
This is part of work addressing the situation regarding teams administering Concourse secrets. It will provide a mechanism to manage secrets without having to hijack/intercept Concourse containers.

# What
This adds a module for creating a IAM role and associated policy, with the aim that future work will allow assuming that role through GitHub authentication and membership of a specific GitHub team.