### PR TITLE
Create a swapfile on the Concourse monitoring Prometheus instances

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
@@ -9,6 +9,13 @@ apt-get upgrade --yes
 export AWS_REGION=eu-west-2
 export AWS_DEFAULT_REGION=eu-west-2
 
+# Create a swapfile
+fallocate -l 4G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+echo "/swapfile swap swap defaults 0 0" >> /etc/fstab
+
 # Guard against Prometheus crashing because of a /etc/resolv.conf
 # parsing issue https://github.com/miekg/dns/pull/642
 rm /etc/resolv.conf


### PR DESCRIPTION
During initial setup. Prometheus seems to use lots of memory when
starting up and reading through the WAL, and a swapfile avoids it
crashing when doing this. I think it's also a generally good thing to
have.