### PR TITLE
Upgrade RDS PostgreSQL for Concourse from 10 to 13

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/rds.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/rds.tf
@@ -23,7 +23,7 @@ resource "aws_db_instance" "concourse" {
   storage_type                 = var.db_storage_type
   iops                         = var.db_storage_iops
   engine                       = "postgres"
-  engine_version               = "10"
+  engine_version               = "13"
   instance_class               = var.db_instance_type
   final_snapshot_identifier    = "${var.deployment}-concourse-final"
   storage_encrypted            = true


### PR DESCRIPTION
This is generally useful as Concourse recommends the latest
PostgreSQL, but this is also happening in preparation for upgrading
Concourse itself, as the migrations involved in the Concourse upgrade
go faster with the newer PostgreSQL.

https://trello.com/c/y2UWWTtZ/1195-big-concourse-upgrade-postgres-currently-10-13-available