### PR TITLE
concourse secrets admin role: grant `kms:Encrypt` permissions

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-secrets-admin/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-secrets-admin/iam.tf
@@ -63,6 +63,7 @@ resource "aws_iam_role_policy" "concourse_secrets_admin" {
           "kms:ListAliases",
           "kms:Describe*",
           "kms:Decrypt",
+          "kms:Encrypt",
         ]
         Effect = "Allow"
         Resource = var.kms_key_arn


### PR DESCRIPTION
Really part of https://trello.com/c/v6tDw4Yo

Without this we can't set secrets.