### PR TITLE
alter default db instance size to match postgreSQL v13.1 AWS UI requirement.

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/variables.tf
@@ -93,7 +93,7 @@ variable "instance_type" {
 }
 
 variable "db_instance_type" {
-  default = "db.t2.small"
+  default = "db.t3.micro"
 }
 
 variable "db_storage_gb" {


### PR DESCRIPTION
Why
UI demands db.t3.micro as the replacement instance.

What
This change will reflect the AWS UI instance requirement for postgreSQL v13.1 in terraform by setting the default db size to be db.t3.micro (which is equivalent to db.t2.small)