### PR TITLE
concourse secrets admin: add allowed_cidrs variable

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-secrets-admin/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-secrets-admin/iam.tf
@@ -24,7 +24,16 @@ resource "aws_iam_role" "concourse_secrets_admin" {
           Federated = var.iam_oidc_provider_arn
         }
       }
-    ]
+    ] + (length(var.allowed_cidrs) == 0 ? [] : [{
+        Effect = "Deny"
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          NotIpAddress = {
+            "aws:SourceIp" = var.allowed_cidrs
+          }
+        }
+      }
+    ])
   })
 }
 
@@ -68,6 +77,15 @@ resource "aws_iam_role_policy" "concourse_secrets_admin" {
         Effect = "Allow"
         Resource = var.kms_key_arn
       }
-    ]
+    ] + (length(var.allowed_cidrs) == 0 ? [] : [{
+        Effect = "Deny"
+        Action = "*"
+        Condition = {
+          NotIpAddress = {
+            "aws:SourceIp" = var.allowed_cidrs
+          }
+        }
+      }
+    ])
   })
 }

--- a/reliability-engineering/terraform/modules/concourse-secrets-admin/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-secrets-admin/variables.tf
@@ -27,3 +27,8 @@ variable "github_oauth_client_id" {
 variable "trusted_github_team_id" {
   type = string
 }
+
+variable "allowed_cidrs" {
+  default = []
+  type = list(string)
+}


### PR DESCRIPTION
https://trello.com/c/GvbwhfFk

For restricting the IP addresses from which users are able to perform
these actions. Default empty leaves access unrestricted, allowing easy
rollout. Hopefully.