### PR TITLE
concourse-web: bump default db instance to db.t3.small

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/variables.tf
@@ -93,7 +93,7 @@ variable "instance_type" {
 }
 
 variable "db_instance_type" {
-  default = "db.t3.micro"
+  default = "db.t3.small"
 }
 
 variable "db_storage_gb" {


### PR DESCRIPTION
This is used for cd staging currently, and `db.t3.micro` has half the memory of the previous `db.t2.small`. Wondering if this is the cause of cd staging's slowness.