### PR TITLE
concourse secrets admin: support multiple trusted_github_team_ids

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-secrets-admin/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-secrets-admin/variables.tf
@@ -25,7 +25,13 @@ variable "github_oauth_client_id" {
 }
 
 variable "trusted_github_team_id" {
+  default = ""
   type = string
+}
+
+variable "trusted_github_team_ids" {
+  default = []
+  type = list(string)
 }
 
 variable "allowed_cidrs" {


### PR DESCRIPTION
https://trello.com/c/EC1qQ44p

Allowing backwards compatibility with singular argument to allow easy rollout.