### PR TITLE
cd test image: Use PaaS' Alpine image on GHCR

### DIFF
--- a/reliability-engineering/dockerfiles/test.Dockerfile
+++ b/reliability-engineering/dockerfiles/test.Dockerfile
@@ -1,4 +1,4 @@
 # This empty dockerfile is used as a quick test that pushing to ECR works in
 # the concourse-deployer pipeline
-FROM alpine
+FROM ghcr.io/alphagov/paas/alpine:b11f2b9068cd492ffd3b33b9db54a1cf8ad136b3
 RUN date


### PR DESCRIPTION
Rather than pulling from DockerHub where we'll get rate limited.