### PR TITLE
concourse-deployer pipeline: also watch cd-main of tech-ops-private repo

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -26,6 +26,7 @@ resources:
     private_key: ((re-autom8-ci-github-ssh-private-key))
     paths:
       - reliability-engineering/terraform/deployments/((deployment_account_name))/((deployment_name))
+      - reliability-engineering/terraform/deployments/((deployment_account_name))/cd-main
       - reliability-engineering/terraform/modules/gds-ips
 - name: tech-ops
   icon: github


### PR DESCRIPTION
This is referenced by the terraform, so should be taken into consideration for triggering.