### PR TITLE
cd roll instances pipeline: ensure asg is rolled in before starting procedure

### DIFF
--- a/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
+++ b/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
@@ -27,6 +27,15 @@ run:
     fly -t concourse sync
     fly -t concourse teams --json | jq 'def rolltasks: [
       {
+        "task": ("ensure-" + .name + "-team-workers-asg-scaled-in"),
+        "file": "tech-ops/reliability-engineering/pipelines/tasks/asg-scale-capacity.yml",
+        "params": {
+          "ASG_PREFIX": (("((" + "deployment_name" + "))") + "-" + .name + "-concourse-worker"),
+          "SCALE_DIRECTION": "in",
+          "SUSPEND_SCHEDULED_SCALING_BEFORE": true
+        }
+      },
+      {
         "task": ("get-current-" + .name + "-team-workers"),
         "file": "tech-ops/reliability-engineering/pipelines/tasks/concourse-get-workers.yml",
         "params": {
@@ -41,8 +50,7 @@ run:
         "file": "tech-ops/reliability-engineering/pipelines/tasks/asg-scale-capacity.yml",
         "params": {
           "ASG_PREFIX": (("((" + "deployment_name" + "))") + "-" + .name + "-concourse-worker"),
-          "SCALE_DIRECTION": "out",
-          "SUSPEND_SCHEDULED_SCALING_BEFORE": true
+          "SCALE_DIRECTION": "out"
         }
       },
       {


### PR DESCRIPTION
https://trello.com/c/5Y0bsLvf

An asg which for some reason is not at its minimum instance count (likely due to scheduled scaling) when this procedure is followed would not end up with entirely new workers. Though it _would_ likely exist for a period where it had zero workers (because we land them *all*, assuming new workers already exist), which is also not good.

So first run a "scale in", which in most cases should be a no-op. In cases where it *does* shut down workers, those workers will be shut down less gracefully than the process normally would because we don't pre-land them - we can't because we don't know the names of the workers which the asg will choose to shut down.

Ideally we will make workers self-drain gracefully at some point, making
all of this work much nicer.