### PR TITLE
cd web nodes: run periodic memory-available checks, setting ASG-health below a threshold

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-web/iam.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/iam.tf
@@ -83,6 +83,14 @@ resource "aws_iam_policy" "concourse_web" {
         "Resource": [
           "arn:aws:logs:*:*:*"
         ]
+      }, {
+        "Effect": "Allow",
+        "Action": [
+          "autoscaling:SetInstanceHealth"
+        ],
+        "Resource": [
+          "${aws_autoscaling_group.concourse_web.arn}"
+        ]
       }
     ]
   }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178781753

concourse-web nodes running out of memory lead to unpredictable behaviour that can be difficult to recover from. suggest to the ASGthat such nodes should be recycled.

`awk` because there aren't many ways to do ~zero-dependency fractional-precision arithmetic in the shell.

To make this possible, I needed to add a permission to the web node's instance policy to allow it to mark itself unhealthy.  In theory the policy allows an ASG member to mark its *siblings* unhealthy too, which is not ideal. Ideally we would only allow an instance to mark *itself* unhealthy in the ASG, but it's not obvious if it's even possible to restrict the policy that way.