### PR TITLE
concourse-monitoring: Restrict service discovery to the relevant deployment

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
@@ -89,6 +89,9 @@ scrape_configs:
         refresh_interval: 30s
         port: 9100
     relabel_configs:
+      - source_labels: [__meta_ec2_tag_Name]
+        regex: '^${deployment}-concourse.*'
+        action: keep
       - source_labels: [__meta_ec2_instance_id]
         target_label: instance
       - source_labels: [__meta_ec2_tag_Role]

--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus.yml
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus.yml
@@ -32,6 +32,9 @@ scrape_configs:
         refresh_interval: 30s
         port: 9100
     relabel_configs:
+      - source_labels: [__meta_ec2_tag_Name]
+        regex: '^${deployment}-concourse.*'
+        action: keep
       - source_labels: [__meta_ec2_instance_id]
         target_label: instance
       - source_labels: [__meta_ec2_tag_Role]


### PR DESCRIPTION
@risicle spotted something weird in prod monitoring this morning - we'd grown
an extra web node.
Turns out prod prometheus was discovering one of the staging web nodes.
Normally, prometheus will look at an instance in another VPC and decide it's
not up, because it can't talk to it, and won't scrape any metrics.
But last night during node rolling one of the prod workers happened to be
randomly assigned an IP that was identical to a staging web node.
So, prod prometheus was discovering the IP from EC2, and then tried to scrape
it for metrics, thought it was talking to one of its web nodes, but actually
had a random prod worker node.