### PR TITLE
BAU: Parameterise if destruction protection is enabled

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-subnets/eips.tf
+++ b/reliability-engineering/terraform/modules/concourse-subnets/eips.tf
@@ -7,7 +7,7 @@ resource "aws_eip" "concourse_egress" {
   }
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = var.deletion_protection
   }
 }
 

--- a/reliability-engineering/terraform/modules/concourse-subnets/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-subnets/variables.tf
@@ -22,6 +22,11 @@ variable "number_of_availability_zones" {
   default = 2
 }
 
+variable "deletion_protection" {
+  type = bool
+  default = true
+}
+
 data "aws_availability_zones" "available" {
 }
 

--- a/reliability-engineering/terraform/modules/concourse-web/rds.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/rds.tf
@@ -30,7 +30,7 @@ resource "aws_db_instance" "concourse" {
   vpc_security_group_ids       = [aws_security_group.concourse_db.id]
   ca_cert_identifier           = "rds-ca-2019"
   performance_insights_enabled = var.db_performance_insights_enabled
-  deletion_protection          = true
+  deletion_protection          = var.deletion_protection
   multi_az                     = var.db_multi_az
   backup_retention_period      = var.db_backup_retention_period
   apply_immediately            = var.db_apply_immediately

--- a/reliability-engineering/terraform/modules/concourse-web/variables.tf
+++ b/reliability-engineering/terraform/modules/concourse-web/variables.tf
@@ -132,6 +132,11 @@ variable "concourse_sha1" {
   type = string
 }
 
+variable "deletion_protection" {
+  type = bool
+  default = true
+}
+
 data "aws_caller_identity" "account" {}
 
 locals {


### PR DESCRIPTION
This allows easier destruction of Concourse, this has been useful for trialling Multi Tenant Concourse in new  environments.

This will enable users that import concourse as a module to more easily tear down environments without having to edit the Tech-Ops repo.