### PR TITLE
cd verify-tag task: temporarily restore to allow us to roll #281 out

### DIFF
--- a/reliability-engineering/pipelines/tasks/verify-tag.yml
+++ b/reliability-engineering/pipelines/tasks/verify-tag.yml
@@ -1,0 +1,37 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: ghcr.io/alphagov/automate/task-toolbox
+    tag: latest
+inputs:
+- name: repository
+params:
+  GPG_VERIFICATION_KEY:
+  GPG_VERIFICATION_TAG:
+run:
+  path: sh
+  args:
+    - -euo
+    - pipefail
+    - -c
+    - |
+      echo "checking if we need to verify this tag..."
+      if [ -z "${GPG_VERIFICATION_TAG}" ]; then
+        echo "+------------------------------------------------------------------+"
+        echo "| tag verification will be skipped as GPG_VERIFICATION_TAG not set |"
+        echo "+------------------------------------------------------------------+"
+        exit 0
+      fi
+      echo "configuring trusted keys..."
+      echo "${GPG_VERIFICATION_KEY}" > key
+      gpg --import key
+      export GPG_TTY=$(tty)
+      export TERM=xterm
+      echo "trusted keys..."
+      gpg --list-keys
+      echo "finding tag..."
+      cd repository
+      TAG=$(cat .git/ref)
+      echo "verifying $TAG signed by a trusted key..."
+      git tag -v "${TAG}"


### PR DESCRIPTION
Once this has been released, *then* we can remove the no-longer-used task file.