### PR TITLE
concourse-monitoring: do prometheus ec2 discovery using dedicated tags

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus-init.sh
@@ -66,8 +66,11 @@ scrape_configs:
         refresh_interval: 30s
         port: 9090
     relabel_configs:
-      - source_labels: [__meta_ec2_tag_Name]
-        regex: '^${deployment}-concourse-prometheus$'
+      - source_labels: [__meta_ec2_tag_Deployment]
+        regex: '${deployment}'
+        action: keep
+      - source_labels: [__meta_ec2_tag_Role]
+        regex: 'prometheus'
         action: keep
       - source_labels: [__meta_ec2_instance_id]
         target_label: instance
@@ -89,8 +92,8 @@ scrape_configs:
         refresh_interval: 30s
         port: 9100
     relabel_configs:
-      - source_labels: [__meta_ec2_tag_Name]
-        regex: '^${deployment}-concourse.*'
+      - source_labels: [__meta_ec2_tag_Deployment]
+        regex: '${deployment}'
         action: keep
       - source_labels: [__meta_ec2_instance_id]
         target_label: instance
@@ -105,8 +108,11 @@ scrape_configs:
         refresh_interval: 30s
         port: 9391
     relabel_configs:
-      - source_labels: [__meta_ec2_tag_Name]
-        regex: '^${deployment}-concourse-web$'
+      - source_labels: [__meta_ec2_tag_Deployment]
+        regex: '${deployment}'
+        action: keep
+      - source_labels: [__meta_ec2_tag_Role]
+        regex: 'concourse-web'
         action: keep
       - source_labels: [__meta_ec2_instance_id]
         target_label: instance

--- a/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus.yml
+++ b/reliability-engineering/terraform/modules/concourse-monitoring/files/prometheus.yml
@@ -9,8 +9,11 @@ scrape_configs:
         refresh_interval: 30s
         port: 9090
     relabel_configs:
-      - source_labels: [__meta_ec2_tag_Name]
-        regex: '^${deployment}-concourse-prometheus$'
+      - source_labels: [__meta_ec2_tag_Deployment]
+        regex: '${deployment}'
+        action: keep
+      - source_labels: [__meta_ec2_tag_Role]
+        regex: 'prometheus'
         action: keep
       - source_labels: [__meta_ec2_instance_id]
         target_label: instance
@@ -32,8 +35,8 @@ scrape_configs:
         refresh_interval: 30s
         port: 9100
     relabel_configs:
-      - source_labels: [__meta_ec2_tag_Name]
-        regex: '^${deployment}-concourse.*'
+      - source_labels: [__meta_ec2_tag_Deployment]
+        regex: '${deployment}'
         action: keep
       - source_labels: [__meta_ec2_instance_id]
         target_label: instance
@@ -48,8 +51,11 @@ scrape_configs:
         refresh_interval: 30s
         port: 9391
     relabel_configs:
-      - source_labels: [__meta_ec2_tag_Name]
-        regex: '^${deployment}-concourse-web$'
+      - source_labels: [__meta_ec2_tag_Deployment]
+        regex: '${deployment}'
+        action: keep
+      - source_labels: [__meta_ec2_tag_Role]
+        regex: 'concourse-web'
         action: keep
       - source_labels: [__meta_ec2_instance_id]
         target_label: instance


### PR DESCRIPTION
Rather than trying to match the mashed-up `Name` tag, which has ambiguity issues around field separators. Or rather the _lack of_ unique field separators. Consider the complications in matching the format `${deployment}-${team}-concourse-worker` when one of your deployment names is a prefix of the other, and all fields are liable to include dashes.

This should hopefully bring back metrics for our worker nodes which had been missing since 778a84b2a540dcc796ee644fd570f1ab6f2f9e63.

Needs to be ported to big-little-concourse afterwards.