### PR TITLE
Zendesk pipeline migration: Allow github actions to use aws oidc for s3

### DIFF
--- a/reliability-engineering/terraform/modules/concourse-worker-pool/s3.tf
+++ b/reliability-engineering/terraform/modules/concourse-worker-pool/s3.tf
@@ -22,6 +22,10 @@ resource "aws_s3_bucket" "concourse_worker_private" {
   }
 }
 
+output "concourse_worker_private_s3_bucket_arn" {
+  value = aws_s3_bucket.concourse_worker_private.arn
+}
+
 resource "random_string" "concourse_worker_public_s3_bucket_offset" {
   length  = 6
   special = false

--- a/reliability-engineering/terraform/modules/github-actions-connectors/vars.tf
+++ b/reliability-engineering/terraform/modules/github-actions-connectors/vars.tf
@@ -1,0 +1,9 @@
+
+variable "zendesk_scripts_output_bucket" {
+  description = "This is a s3 bucket the zendesk tickets output to" 
+}
+
+variable "github_oidc_claim" {
+  description = "The OIDC Claim for the repo"
+  default = "environment:development"  
+}

--- a/reliability-engineering/terraform/modules/github-actions-connectors/zendesk-estate.tf
+++ b/reliability-engineering/terraform/modules/github-actions-connectors/zendesk-estate.tf
@@ -1,0 +1,61 @@
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  thumbprint_list = [
+    "a031c46782e6e6c662c2c87c76da9aa62ccabd8e"
+  ]
+}
+
+resource "aws_iam_role" "gha_zendesk_scripts" {
+  name = "gha-zendesk-scripts-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = concat(
+      [
+        {
+          Effect = "Allow",
+          Principal = {
+            Federated = aws_iam_openid_connect_provider.github_actions.arn
+          },
+          Action = "sts:AssumeRoleWithWebIdentity",
+          Condition = {
+              StringEquals = {
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                "token.actions.githubusercontent.com:sub": "repo:alphagov/zendesk-scripts:${var.github_oidc_claim}"
+              }
+          }
+        }
+      ]
+    )
+  })
+}
+
+
+resource "aws_iam_role_policy" "gha_zendesk_scripts" {
+  name = "gha-zendesk-scripts-role-policy"
+  role = aws_iam_role.gha_zendesk_scripts.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          Action = [
+            "s3:PutObject",
+            "s3:PutObjectAcl",
+          ]
+          Effect = "Allow"
+          Resource = [
+            "${var.zendesk_scripts_output_bucket}",
+            "${var.zendesk_scripts_output_bucket}/*",
+          ]
+        }
+      ]
+    )
+  })
+}

--- a/reliability-engineering/terraform/modules/github-actions-connectors/zendesk-estate.tf
+++ b/reliability-engineering/terraform/modules/github-actions-connectors/zendesk-estate.tf
@@ -6,7 +6,7 @@ resource "aws_iam_openid_connect_provider" "github_actions" {
   ]
 
   thumbprint_list = [
-    "a031c46782e6e6c662c2c87c76da9aa62ccabd8e"
+    "a031c46782e6e6c662c2c87c76da9aa62ccabd8e" # This is a magic string, if you want to know why its so magical read this -> https://stackoverflow.com/a/69247499
   ]
 }
 


### PR DESCRIPTION
This is PR 1 of 2 theres is the other half of the implementation over on tech-ops-private.

This creates the OIDC provider and associated roles to allow Github actions to access s3.
Enabling us to move the zendesk scripts off Concourse as the results are put into S3.

Other modification is to allow us to get the ARN of the existing bucket ready for use in prod.