### PR TITLE
GHA Octodns build & push GHCR & Docker Hub

### DIFF
--- a/.github/workflows/build_govsvc_docker_octodns.yml
+++ b/.github/workflows/build_govsvc_docker_octodns.yml
@@ -1,0 +1,44 @@
+name: govsvc octodns
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'reliability-engineering/dockerfiles/govsvc/octodns/**'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # v1.6.0
+      - name: Login to DockerHub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9 # v1.10.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9 # v1.10.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229 # v2.7.0
+        with:
+          context: ./reliability-engineering/dockerfiles/govsvc/octodns
+          push: true
+          tags: |
+            govsvc/octodns:latest
+            ghcr.io/govsvc/octodns:latest


### PR DESCRIPTION
This is to replace the current build for the [Octodns docker image](https://github.com/orgs/alphagov/packages/container/package/octodns) that currently lives on the big concourse. This is the first of 4 docker images we build and release to GHCR & Dockerhub.

This has been tested on a fork https://github.com/tomrosier/tech-ops/runs/4324805291?check_suite_focus=true

And does publish to dockerhub successfully.
<img width="1315" alt="Screenshot 2021-11-25 at 15 09 47" src="https://user-images.githubusercontent.com/14276821/143465345-fbffc66e-f83f-420f-9cbf-a05841fcc902.png">


