### PR TITLE
Checkout repo in build docker images octodns

### DIFF
--- a/.github/workflows/build_govsvc_docker_octodns.yml
+++ b/.github/workflows/build_govsvc_docker_octodns.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # 2.4.0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
       - name: Set up Docker Buildx


### PR DESCRIPTION
It was missing the docker files when it was trying to run, so checking out the repo before hand should mean they are there.