### PR TITLE
Remove template provider

### DIFF
--- a/cyber-security/modules/gds_security_audit_role/gds_security_audit_role.tf
+++ b/cyber-security/modules/gds_security_audit_role/gds_security_audit_role.tf
@@ -1,16 +1,10 @@
-data "template_file" "trust" {
-  template = file("${path.module}/json/trust.json")
-
-  vars = {
-    prefix           = var.prefix
-    chain_account_id = var.chain_account_id
-  }
-}
-
 resource "aws_iam_role" "gds_security_audit_role" {
   name = "${var.prefix}GDSSecurityAudit"
 
-  assume_role_policy = data.template_file.trust.rendered
+  assume_role_policy = templatefile("${path.module}/json/trust.json", {
+    prefix           = var.prefix
+    chain_account_id = var.chain_account_id
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "gds_security_audit_role_policy_attachment" {


### PR DESCRIPTION
The template provider (which provides the `template_file` data source)
[is deprecated][1], we should use the `templatefile` function now.

The template provider is also not available on the darwin_arm64
platform, so won't run natively on M1 macs.

[1]: https://registry.terraform.io/providers/hashicorp/template/latest/docs#deprecation