### PR TITLE
Add parameters to workflow that dockerfile needs

### DIFF
--- a/.github/workflows/build_govsvc_docker_aws_terraform.yml
+++ b/.github/workflows/build_govsvc_docker_aws_terraform.yml
@@ -13,6 +13,18 @@ on:
         description: "Tag used within docker repository to mark as unique"
         required: false
         type: string
+      terraform_version:
+        description: "Terraform version to be used"
+        required: true
+        type: string
+      terraform_digest:
+        description: "Terraform SHA of the version to be used"
+        required: true
+        type: string
+      ubuntu_digest:
+        description: "Ubuntu SHA of the version to be used"
+        required: true
+        type: string
 
 jobs:
   build-and-push:
@@ -20,10 +32,13 @@ jobs:
     with:
       docker_context: ./reliability-engineering/dockerfiles/govsvc/aws-terraform
       push_to_ghcr: true
-      push_to_dockerhub: true
-      docker_hub_repo: govsvc/aws-terraform
+      push_to_dockerhub: false
       ghcr_repo: ghcr.io/alphagov/aws-terraform
       image_tag: ${{ github.event.inputs.image_tag }}
     secrets:
       ghcr_username: ${{ secrets.GHCR_USERNAME }}
       ghcr_token: ${{ secrets.CHCR_TOKEN }}
+    build-args:
+      terraform_version: ${{ github.event.inputs.terraform_version }}
+      terraform_digest: ${{ github.event.inputs.terraform_digest }}
+      ubuntu_digest: ${{ github.event.inputs.ubuntu_digest }}


### PR DESCRIPTION
We require the following arguments to be passed to the aws_terraform dockerfile

```
ARG ubuntu_digest
ARG terraform_digest
ARG terraform_version
``` 
There is currently no way to do this.