### PR TITLE
Remove terraform build args

### DIFF
--- a/.github/workflows/build_govsvc_docker_aws_terraform.yml
+++ b/.github/workflows/build_govsvc_docker_aws_terraform.yml
@@ -13,18 +13,6 @@ on:
         description: "Tag used within docker repository to mark as unique"
         required: false
         type: string
-      terraform_version:
-        description: "Terraform version to be used"
-        required: true
-        type: string
-      terraform_digest:
-        description: "Terraform SHA of the version to be used"
-        required: true
-        type: string
-      ubuntu_digest:
-        description: "Ubuntu SHA of the version to be used"
-        required: true
-        type: string
 
 jobs:
   build-and-push:
@@ -38,7 +26,3 @@ jobs:
     secrets:
       ghcr_username: ${{ secrets.GHCR_USERNAME }}
       ghcr_token: ${{ secrets.CHCR_TOKEN }}
-    build-args:
-      terraform_version: ${{ github.event.inputs.terraform_version }}
-      terraform_digest: ${{ github.event.inputs.terraform_digest }}
-      ubuntu_digest: ${{ github.event.inputs.ubuntu_digest }}

--- a/reliability-engineering/dockerfiles/govsvc/aws-terraform/Dockerfile
+++ b/reliability-engineering/dockerfiles/govsvc/aws-terraform/Dockerfile
@@ -1,14 +1,19 @@
-ARG ubuntu_digest
-ARG terraform_digest
-ARG terraform_version
+FROM hashicorp/terraform:1.2.0 as terraform
+FROM ubuntu:20.04
 
-FROM hashicorp/terraform@${terraform_digest} as terraform
-FROM ubuntu@${ubuntu_digest}
+LABEL terraform="1.2.0"
 
-LABEL terraform="${terraform_version}"
+ARG APT_GET_DEPENDENCIES="\
+ awscli \
+ curl \
+ dnsutils \
+ git \
+ jq \
+ unzip \
+"
 
-RUN apt-get update  --yes && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes awscli jq curl dnsutils unzip git
+RUN apt update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
+RUN apt upgrade -y && TZ=Etc/UTC apt install --no-install-recommends -y ${APT_GET_DEPENDENCIES} && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
 


### PR DESCRIPTION
Simplifying the dockerfile and build process makes much more sense, we're not running matrix builds here.