### PR TITLE
Update docker hub repo to be the central repo

### DIFF
--- a/.github/workflows/build_govsvc_docker_aws_ruby.yml
+++ b/.github/workflows/build_govsvc_docker_aws_ruby.yml
@@ -21,12 +21,12 @@ jobs:
       docker_context: ./reliability-engineering/dockerfiles/govsvc/aws-ruby
       push_to_ghcr: true
       push_to_dockerhub: true
-      docker_hub_repo: govsvc/aws-ruby
+      docker_hub_repo: governmentdigitalservice/aws-ruby
       ghcr_repo: ghcr.io/alphagov/aws-ruby
       image_tag: ${{ github.event.inputs.image_tag }}
     secrets:
-      dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }} 
+      dockerhub_username: ${{ secrets.BOT_DOCKERHUB_USERNAME }}
+      dockerhub_token: ${{ secrets.BOT_DOCKERHUB_TOKEN }} 
       ghcr_username: ${{ secrets.GHCR_USERNAME }}
       ghcr_token: ${{ secrets.CHCR_TOKEN }}
                       

--- a/.github/workflows/build_govsvc_docker_aws_terraform.yml
+++ b/.github/workflows/build_govsvc_docker_aws_terraform.yml
@@ -23,9 +23,12 @@ jobs:
     with:
       docker_context: ./reliability-engineering/dockerfiles/govsvc/aws-terraform
       push_to_ghcr: true
-      push_to_dockerhub: false
+      push_to_dockerhub: true
+      docker_hub_repo: governmentdigitalservice/aws-terraform
       ghcr_repo: ghcr.io/alphagov/aws-terraform
       image_tag: ${{ github.event.inputs.image_tag }}
     secrets:
+      dockerhub_username: ${{ secrets.BOT_DOCKERHUB_USERNAME }}
+      dockerhub_token: ${{ secrets.BOT_DOCKERHUB_TOKEN }}
       ghcr_username: ${{ secrets.GHCR_CI_USERNAME }}
       ghcr_token: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/build_govsvc_docker_awsc.yml
+++ b/.github/workflows/build_govsvc_docker_awsc.yml
@@ -16,11 +16,11 @@ jobs:
       docker_context: ./reliability-engineering/dockerfiles/govsvc/awsc
       push_to_ghcr: true
       push_to_dockerhub: true
-      docker_hub_repo: govsvc/awsc
+      docker_hub_repo: governmentdigitalservice/awsc
       ghcr_repo: ghcr.io/alphagov/awsc
     secrets:
-      dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }} 
+      dockerhub_username: ${{ secrets.BOT_DOCKERHUB_USERNAME }}
+      dockerhub_token: ${{ secrets.BOT_DOCKERHUB_TOKEN }} 
       ghcr_username: ${{ secrets.GHCR_USERNAME }}
       ghcr_token: ${{ secrets.CHCR_TOKEN }}
                       

--- a/.github/workflows/build_govsvc_docker_concourse_task_toolbox.yml
+++ b/.github/workflows/build_govsvc_docker_concourse_task_toolbox.yml
@@ -22,10 +22,10 @@ jobs:
       push_to_ghcr: true
       push_to_dockerhub: true
       ghcr_repo: ghcr.io/alphagov/automate/task-toolbox
-      docker_hub_repo: govsvc/task-toolbox
+      docker_hub_repo: governmentdigitalservice/task-toolbox
       image_tag: ${{ github.event.inputs.image_tag }}
     secrets:
       ghcr_username: ${{ secrets.GHCR_USERNAME }}
       ghcr_token: ${{ secrets.CHCR_TOKEN }}
-      dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }} 
+      dockerhub_username: ${{ secrets.BOT_DOCKERHUB_USERNAME }}
+      dockerhub_token: ${{ secrets.BOT_DOCKERHUB_TOKEN }} 

--- a/.github/workflows/build_govsvc_docker_octodns.yml
+++ b/.github/workflows/build_govsvc_docker_octodns.yml
@@ -16,11 +16,11 @@ jobs:
       docker_context: ./reliability-engineering/dockerfiles/govsvc/octodns
       push_to_ghcr: true
       push_to_dockerhub: true
-      docker_hub_repo: govsvc/octodns
+      docker_hub_repo: governmentdigitalservice/octodns
       ghcr_repo: ghcr.io/alphagov/octodns
     secrets:
-      dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }} 
+      dockerhub_username: ${{ secrets.BOT_DOCKERHUB_USERNAME }}
+      dockerhub_token: ${{ secrets.BOT_DOCKERHUB_TOKEN }} 
       ghcr_username: ${{ secrets.GHCR_USERNAME }}
       ghcr_token: ${{ secrets.CHCR_TOKEN }}
                       

--- a/.github/workflows/publish_to_docker.yml
+++ b/.github/workflows/publish_to_docker.yml
@@ -58,8 +58,8 @@ jobs:
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2.0.0
         if: ${{ inputs.push_to_dockerhub }}
         with:
-          username: ${{ secrets.dockerhub_username }}
-          password: ${{ secrets.dockerhub_token }}
+          username: ${{ secrets.bot_dockerhub_username }}
+          password: ${{ secrets.bot_dockerhub_token }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2.0.0
         if: ${{ inputs.push_to_ghcr }}

--- a/README.md
+++ b/README.md
@@ -12,24 +12,24 @@ Pipeline runs will have to be approved by a trusted person that is in the `re-au
 #### AWSC
 [:rocket: Github Action](https://github.com/alphagov/tech-ops/actions/workflows/build_govsvc_docker_awsc.yml)
 [:octocat: GHCR Repo](https://github.com/orgs/alphagov/packages/container/package/awsc)
-[:whale: Dockerhub Repo](https://hub.docker.com/r/govsvc/awsc)
+[:whale: Dockerhub Repo](https://hub.docker.com/r/governmentdigitalservice/awsc)
 
 #### AWS Terraform
 [:rocket: Github Action](https://github.com/alphagov/tech-ops/actions/workflows/build_govsvc_docker_aws_terraform.yml)
 [:octocat: GHCR Repo](https://github.com/orgs/alphagov/packages/container/package/aws-terraform)
-[:whale: Dockerhub Repo](https://hub.docker.com/r/govsvc/aws-terraform)
+[:whale: Dockerhub Repo](https://hub.docker.com/r/governmentdigitalservice/aws-terraform)
 
 #### AWS Ruby
 [:rocket: Github Action](https://github.com/alphagov/tech-ops/actions/workflows/build_govsvc_docker_aws_ruby.yml)
 [:octocat: GHCR Repo](https://github.com/orgs/alphagov/packages/container/package/aws-ruby)
-[:whale: Dockerhub Repo](https://hub.docker.com/r/govsvc/aws-ruby)
+[:whale: Dockerhub Repo](https://hub.docker.com/r/governmentdigitalservice/aws-ruby)
 
 #### OctoDNS
 [:rocket: Github Action](https://github.com/alphagov/tech-ops/actions/workflows/build_govsvc_docker_octodns.yml)
 [:octocat: GHCR Repo](https://github.com/orgs/alphagov/packages/container/package/octodns)
-[:whale: Dockerhub Repo](https://hub.docker.com/r/govsvc/octodns)
+[:whale: Dockerhub Repo](https://hub.docker.com/r/ggovernmentdigitalservice/octodns)
 
 #### Autom8 Task Toolbox
 [:rocket: Github Action](https://github.com/alphagov/tech-ops/actions/workflows/build_govsvc_docker_concourse_task_toolbox.yml)
 [:octocat: GHCR Repo](https://github.com/orgs/alphagov/packages/container/package/automate%2Ftask-toolbox)
-[:whale: Dockerhub Repo](https://hub.docker.com/r/govsvc/task-toolbox)
+[:whale: Dockerhub Repo](https://hub.docker.com/r/governmentdigitalservice/task-toolbox)


### PR DESCRIPTION
We have a collection of rdockerhub repos all over the place, this is an issue with the Joiners, Movers and Leavers process. Migrating to the central account that is paid for and has the ability to manage users against the domain is a sensible way forwards.