### PR TITLE
Dockerfile updates

### DIFF
--- a/.github/workflows/publish_to_docker.yml
+++ b/.github/workflows/publish_to_docker.yml
@@ -77,7 +77,7 @@ jobs:
             TAGS="${{ inputs.docker_hub_repo }}:latest,"
 
             if [ "${{ inputs.image_tag }}" != "" ]; then
-              TAGS="${TAGS}${{ inputs.docker_hub_repo }}:${{ inputs.image_tag }}"
+              TAGS="${TAGS}${{ inputs.docker_hub_repo }}:${{ inputs.image_tag }},"
             fi
           fi
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Pipeline runs will have to be approved by a trusted person that is in the `re-au
 #### OctoDNS
 [:rocket: Github Action](https://github.com/alphagov/tech-ops/actions/workflows/build_govsvc_docker_octodns.yml)
 [:octocat: GHCR Repo](https://github.com/orgs/alphagov/packages/container/package/octodns)
-[:whale: Dockerhub Repo](https://hub.docker.com/r/ggovernmentdigitalservice/octodns)
+[:whale: Dockerhub Repo](https://hub.docker.com/r/governmentdigitalservice/octodns)
 
 #### Autom8 Task Toolbox
 [:rocket: Github Action](https://github.com/alphagov/tech-ops/actions/workflows/build_govsvc_docker_concourse_task_toolbox.yml)

--- a/reliability-engineering/dockerfiles/govsvc/awsc/Dockerfile
+++ b/reliability-engineering/dockerfiles/govsvc/awsc/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang:1.12
+FROM golang:1.18
 
 ENV AWSC_VERSION 50283d253d3f5600dc53d5c1454a4ab7cbfccfe4
-ENV GO111MODULE  on
 
-RUN go get github.com/alphagov/awsc@$AWSC_VERSION
+RUN go install github.com/alphagov/awsc@$AWSC_VERSION
 
 RUN apt-get update  --yes && \
     apt-get install --yes awscli jq


### PR DESCRIPTION
Should fix both

```
Error: buildx failed with: error: invalid tag "governmentdigitalservice/aws-ruby:2.6.1ghcr.io/alphagov/aws-ruby:latest": invalid reference format
```

and 

```
Error: buildx failed with: error: invalid tag "governmentdigitalservice/task-toolbox:0.3ghcr.io/alphagov/automate/task-toolbox:latest": invalid reference format
```

Also updates the version of go used in the awsc container to correct

```
buildx failed with: error: failed to solve: process "/bin/sh -c go get github.com/alphagov/awsc@$AWSC_VERSION" did not complete successfully: exit code: 1
```