### PR TITLE
Add terraform 1.2.7 image for use in pipelines

### DIFF
--- a/reliability-engineering/dockerfiles/govsvc/aws-terraform/Dockerfile
+++ b/reliability-engineering/dockerfiles/govsvc/aws-terraform/Dockerfile
@@ -1,7 +1,7 @@
-FROM hashicorp/terraform:1.2.3 as terraform
+FROM hashicorp/terraform:1.2.7 as terraform
 FROM ubuntu:20.04
 
-LABEL terraform="1.2.0"
+LABEL terraform="1.2.7"
 
 ARG APT_GET_DEPENDENCIES="\
  awscli \


### PR DESCRIPTION
It's the latest (i.e. current) version so we should have it available for use. 