### PR TITLE
deployer: Bump terraform version tag

### DIFF
--- a/reliability-engineering/pipelines/concourse-deployer.yml
+++ b/reliability-engineering/pipelines/concourse-deployer.yml
@@ -6,7 +6,7 @@ resource_types:
   type: registry-image
   source:
     repository: ljfranklin/terraform-resource
-    tag: 0.13.5
+    tag: 1.2.7
 - name: pool
   type: registry-image
   source:


### PR DESCRIPTION
## What

The state of the bucket is currently at 1.2.7, which means our pipelines is essentially blocked on terraform trying to execute using the old version.

Bumping the version to the one persisting in the S3 bucket. May look at the reasons how it got bumped later.