### PR TITLE
concourse-tasks: update the alpine keys

### DIFF
--- a/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
+++ b/reliability-engineering/pipelines/tasks/generate-deploy-info-pipelines-pipeline.yml
@@ -22,6 +22,7 @@ run:
   - pipefail
   - -c
   - |
+    apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.16/main -u alpine-keys
     apk update && apk add jq
     mkdir -p deploy-info-pipelines-pipeline
     export PATH="$PATH:/opt/resource"

--- a/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
+++ b/reliability-engineering/pipelines/tasks/generate-roll-instances-pipeline.yml
@@ -22,6 +22,7 @@ run:
   - pipefail
   - -c
   - |
+    apk add -X https://dl-cdn.alpinelinux.org/alpine/v3.16/main -u alpine-keys
     apk update && apk add jq && apk add yq
     mkdir -p roll-instances-pipeline
     export PATH="$PATH:/opt/resource"

--- a/reliability-engineering/terraform/modules/github-actions-connectors/zendesk-estate.tf
+++ b/reliability-engineering/terraform/modules/github-actions-connectors/zendesk-estate.tf
@@ -56,9 +56,9 @@ resource "aws_iam_role_policy" "gha_zendesk_scripts" {
           ]
           Effect = "Allow"
           Resource = [
-            "${var.zendesk_scripts_output_bucket}",
+            var.zendesk_scripts_output_bucket,
             "${var.zendesk_scripts_output_bucket}/*",
-            "${aws_s3_bucket.zendesk_deduplication_logs.arn}",
+            aws_s3_bucket.zendesk_deduplication_logs.arn,
             "${aws_s3_bucket.zendesk_deduplication_logs.arn}/*",
           ]
         }


### PR DESCRIPTION
## What

We're currently getting number of errors whilst attempting to run
`apk-update`.

The errors we're seeing:
```
fetch https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
ERROR: https://dl-cdn.alpinelinux.org/alpine/edge/main: UNTRUSTED signature
WARNING: Ignoring APKINDEX.e37b76c2.tar.gz: No such file or directory
2 errors; 20 distinct packages available
/bin/bash: line 11: yq: command not found
```

This [slackoverflow][1] along with the [official alpine announcement][2]
is suggesting having to simply update the alpine keys first, before
executing any other apk commands.

[1]: https://stackoverflow.com/questions/73374745/error-http-dl-4-alpinelinux-org-alpine-edge-testing-untrusted-signature
[2]: https://www.alpinelinux.org/posts/Alpine-edge-signing-keys-rotated.html